### PR TITLE
Adding schema mapping module for Cassandra to Bigtable proxy

### DIFF
--- a/cassandra-bigtable-proxy/schema-mapping/schema_mapping.go
+++ b/cassandra-bigtable-proxy/schema-mapping/schema_mapping.go
@@ -1,0 +1,357 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package schemaMapping
+
+import (
+	"fmt"
+
+	"github.com/datastax/go-cassandra-native-protocol/datatype"
+	"github.com/datastax/go-cassandra-native-protocol/message"
+	"go.uber.org/zap"
+)
+
+const (
+	limitValue = "limitValue"
+)
+
+type Column struct {
+	CQLType      string
+	ColumnName   string
+	ColumnType   string
+	IsPrimaryKey bool
+	PkPrecedence int64
+	IsCollection bool
+	KeyType      string
+	Metadata     message.ColumnMetadata
+}
+
+type SchemaMappingConfig struct {
+	Logger             *zap.Logger
+	TablesMetaData     map[string]map[string]map[string]*Column
+	PkMetadataCache    map[string]map[string][]Column
+	SystemColumnFamily string
+}
+
+type ColumnType struct {
+	CQLType      string
+	IsPrimaryKey bool
+	ColumnFamily string
+	IsCollection bool
+	KeyType      string
+}
+
+type SelectedColumns struct {
+	FormattedColumn     string
+	Name                string
+	IsFunc              bool
+	IsAs                bool
+	FuncName            string
+	Alias               string
+	MapKey              string
+	ListIndex           string
+	WriteTime_Column    string
+	KeyType             string
+	Is_WriteTime_Column bool
+}
+
+// GetPkByTableName() searches for and retrieves the primary keys of a specific table
+//
+// Parameters:
+//   - tableName: A string representing the name of the table for which the metadata
+//     is requested.
+//
+// Returns:
+//   - []Column: Array of Column details which are Primary Keys.
+//   - An error: Returns error if function not able to search any primary keys
+func (c *SchemaMappingConfig) GetPkByTableName(tableName string, keySpace string) ([]Column, error) {
+	pkMeta, ok := c.PkMetadataCache[keySpace][tableName]
+	if !ok {
+		return nil, fmt.Errorf("could not find table metadata")
+	}
+	return pkMeta, nil
+}
+
+// GetColumnType() retrieves the column types for a specified column in a specified table.
+// This method is a part of the SchemaMappingConfig struct and is used to map column types
+// from Cassandra (CQL) to Google Cloud Bigtable.
+//
+// Parameters:
+// - tableName: A string representing the name of the table.
+// - columnName: A string representing the name of the column within the specified table.
+//
+// Returns:
+//   - A pointer to a ColumnType struct that contains both the CQL type and the corresponding
+//     cassandra type for the specified column.
+//   - An error if the function is unable to determine the corresponding cassandra type.
+func (c *SchemaMappingConfig) GetColumnType(tableName string, columnName string, keySpace string) (*ColumnType, error) {
+
+	td, ok := c.TablesMetaData[keySpace][tableName]
+	if !ok {
+		return nil, fmt.Errorf("could not find table metadata")
+	}
+
+	col, ok := td[columnName]
+	if !ok {
+		return nil, fmt.Errorf("could not find column metadata")
+	}
+
+	return &ColumnType{
+		CQLType:      col.ColumnType,
+		IsPrimaryKey: col.IsPrimaryKey,
+		IsCollection: col.IsCollection,
+		KeyType:      col.KeyType,
+	}, nil
+}
+
+// GetMetadataForColumns() retrieves metadata for specific columns in a given table.
+// This method is a part of the SchemaMappingConfig struct.
+//
+// Parameters:
+//   - tableName: The name of the table for which column metadata is being requested.
+//   - columnNames(optional):Accepts nil if no columnNames provided or else A slice of strings containing the names of the columns for which
+//     metadata is required. If this slice is empty, metadata for all
+//     columns in the table will be returned.
+//
+// Returns:
+// - A slice of pointers to ColumnMetadata structs containing metadata for each requested column.
+// - An error if the specified table is not found in the TablesMetaData.
+func (c *SchemaMappingConfig) GetMetadataForColumns(tableName string, columnNames []string, keySpace string) ([]*message.ColumnMetadata, error) {
+	columnsMap, ok := c.TablesMetaData[keySpace][tableName]
+	if !ok {
+		c.Logger.Error("Table not found in Column MetaData Cache")
+		return nil, fmt.Errorf("table %s not found", tableName)
+	}
+
+	if len(columnNames) == 0 {
+		return c.getAllColumnsMetadata(columnsMap), nil
+	}
+
+	return c.getSpecificColumnsMetadata(columnsMap, columnNames, tableName)
+}
+
+// GetMetadataForSelectedColumns() simply fetching column metadata for selected columns .
+//
+// Parameters:
+//   - tableName: The name of the table for which column metadata is being requested.
+//   - columnNames(optional): []SelectedColumns - Accepts nil if no columnNames provided or else A slice of strings containing the names of the columns for which
+//     metadata is required. If this slice is empty, metadata for all
+//     columns in the table will be returned.
+//
+// Returns:
+// - A slice of pointers to ColumnMetadata structs containing metadata for each requested column.
+// - An error if the specified table is not found in the TablesMetaData.
+func (c *SchemaMappingConfig) GetMetadataForSelectedColumns(tableName string, columnNames []SelectedColumns, keySpace string) ([]*message.ColumnMetadata, error) {
+	columnsMap, ok := c.TablesMetaData[keySpace][tableName]
+	if !ok {
+		c.Logger.Error("Table not found in Column MetaData Cache")
+		return nil, fmt.Errorf("table %s not found", tableName)
+	}
+
+	if len(columnNames) == 0 {
+		return c.getAllColumnsMetadata(columnsMap), nil
+	}
+	return c.getSpecificColumnsMetadataForSelectedColumns(columnsMap, columnNames, tableName)
+}
+
+// getTimestampColumnName() constructs the appropriate name for a column used in a writetime function.
+//
+// Parameters:
+//   - aliasName: A string representing the alias of the column, if any.
+//   - columnName: The actual name of the column for which the writetime function is being constructed.
+//
+// Returns: A string which is either the alias name or the expression "writetime(columnName)"
+//
+//	if no alias is provided.
+func getTimestampColumnName(aliasName string, columnName string) string {
+	if aliasName == "" {
+		return "writetime(" + columnName + ")"
+	}
+	return aliasName
+}
+
+// getSpecificColumnsMetadataForSelectedColumns() generates column metadata for specifically selected columns.
+// It handles regular columns, writetime columns, and special columns, and logs an error for invalid configurations.
+//
+// Parameters:
+//   - columnsMap: A map where the keys are column names and the values are pointers to Column containing metadata.
+//   - selectedColumns: A slice of SelectedColumns representing columns that have been selected for query.
+//   - tableName: The name of the table from which columns are being selected.
+//
+// Returns:
+//   - A slice of pointers to ColumnMetadata, representing the metadata for each selected column.
+//   - An error if a column cannot be found in the map, or if there's an issue handling special columns.
+func (c *SchemaMappingConfig) getSpecificColumnsMetadataForSelectedColumns(columnsMap map[string]*Column, selectedColumns []SelectedColumns, tableName string) ([]*message.ColumnMetadata, error) {
+	var columnMetadataList []*message.ColumnMetadata
+	var columnName string
+	for i, columnMeta := range selectedColumns {
+		columnName = columnMeta.Name
+
+		if column, ok := columnsMap[columnName]; ok {
+			columnMetadataList = append(columnMetadataList, c.cloneColumnMetadata(&column.Metadata, int32(i)))
+		} else if columnMeta.Is_WriteTime_Column {
+			metadata, err := c.handleSpecialColumn(columnsMap, getTimestampColumnName(columnMeta.Alias, columnMeta.WriteTime_Column), int32(i), true)
+			if err != nil {
+				return nil, err
+			}
+			columnMetadataList = append(columnMetadataList, metadata)
+		} else if isSpecialColumn(columnName) {
+			metadata, err := c.handleSpecialColumn(columnsMap, columnName, int32(i), false)
+			if err != nil {
+				return nil, err
+			}
+			columnMetadataList = append(columnMetadataList, metadata)
+		} else if columnMeta.IsFunc {
+			c.Logger.Debug("Identified a function call", zap.String("columnName", columnName))
+		} else {
+			errMsg := fmt.Sprintf("table = `%s` column name = `%s` not found", tableName, columnName)
+			c.Logger.Error(errMsg)
+			return nil, fmt.Errorf("%s", errMsg)
+		}
+	}
+	return columnMetadataList, nil
+}
+
+// getAllColumnsMetadata() retrieves metadata for all columns in a given table.
+//
+// Parameters:
+//   - columnsMap: column info for a given table.
+//
+// Returns:
+// - A slice of pointers to ColumnMetadata structs containing metadata for each requested column.
+// - An error
+func (c *SchemaMappingConfig) getAllColumnsMetadata(columnsMap map[string]*Column) []*message.ColumnMetadata {
+	var columnMetadataList []*message.ColumnMetadata
+	var i int32 = 0
+	for _, column := range columnsMap {
+		columnMt := column.Metadata
+		columnMd := columnMt.Clone()
+		columnMd.Index = i
+		columnMetadataList = append(columnMetadataList, columnMd)
+		i++
+	}
+	return columnMetadataList
+}
+
+// getSpecificColumnsMetadata() retrieves metadata for specific columns in a given table.
+//
+// Parameters:
+//   - columnsMap: column info for a given table.
+//   - columnNames: column names for which the metadata is required.
+//   - tableName: name of the table
+//
+// Returns:
+// - A slice of pointers to ColumnMetadata structs containing metadata for each requested column.
+// - An error
+func (c *SchemaMappingConfig) getSpecificColumnsMetadata(columnsMap map[string]*Column, columnNames []string, tableName string) ([]*message.ColumnMetadata, error) {
+	var columnMetadataList []*message.ColumnMetadata
+	for i, columnName := range columnNames {
+		if column, ok := columnsMap[columnName]; ok {
+			columnMetadataList = append(columnMetadataList, c.cloneColumnMetadata(&column.Metadata, int32(i)))
+		} else if isSpecialColumn(columnName) {
+			metadata, err := c.handleSpecialColumn(columnsMap, columnName, int32(i), false)
+			if err != nil {
+				return nil, err
+			}
+			columnMetadataList = append(columnMetadataList, metadata)
+		} else {
+			errMsg := fmt.Sprintf("table = `%s` column name = `%s` not found", tableName, columnName)
+			c.Logger.Error(errMsg)
+			return nil, fmt.Errorf("%s", errMsg)
+		}
+	}
+	return columnMetadataList, nil
+}
+
+// handleSpecialColumn() retrieves metadata for special columns.
+//
+// Parameters:
+//   - columnsMap: column info for a given table.
+//   - columnName: column name for which the metadata is required.
+//   - index: Index for the column
+//
+// Returns:
+// - Pointers to ColumnMetadata structs containing metadata for each requested column.
+// - An error
+func (c *SchemaMappingConfig) handleSpecialColumn(columnsMap map[string]*Column, columnName string, index int32, iswriteTimeFunction bool) (*message.ColumnMetadata, error) {
+	var expectedType datatype.DataType
+	if columnName == limitValue {
+		expectedType = datatype.Bigint
+	} else if iswriteTimeFunction {
+		expectedType = datatype.Bigint
+	}
+	for _, column := range columnsMap {
+		columnMd := column.Metadata.Clone()
+		columnMd.Index = index
+		columnMd.Name = columnName
+		columnMd.Type = expectedType
+		return columnMd, nil
+	}
+	return nil, fmt.Errorf("special column %s not found", columnName)
+}
+
+// cloneColumnMetadata() clones the metadata from cache.
+//
+// Parameters:
+//   - metadata: Column metadata from cache
+//   - index: Index for the column
+//
+// Returns:
+// - Pointers to ColumnMetadata structs containing metadata for each requested column.
+func (c *SchemaMappingConfig) cloneColumnMetadata(metadata *message.ColumnMetadata, index int32) *message.ColumnMetadata {
+	columnMd := metadata.Clone()
+	columnMd.Index = index
+	return columnMd
+}
+
+// isSpecialColumn() to check if its a special column.
+//
+// Parameters:
+//   - columnName: name of special column
+//
+// Returns:
+// - boolean
+func isSpecialColumn(columnName string) bool {
+	return columnName == limitValue
+}
+
+func (c *SchemaMappingConfig) InstanceExist(keyspace string) bool {
+	_, ok := c.TablesMetaData[keyspace]
+	return ok
+}
+
+func (c *SchemaMappingConfig) TableExist(keyspace string, tableName string) bool {
+	_, ok := c.TablesMetaData[keyspace][tableName]
+	return ok
+}
+
+// GetPkKeyType() returns the key type of a primary key column for a given table and keyspace.
+// It takes the table name, keyspace name, and column name as input parameters.
+// Returns the key type as a string if the column is a primary key, or an error if:
+// - There's an error retrieving primary key information
+// - The specified column is not a primary key in the table
+func (c *SchemaMappingConfig) GetPkKeyType(tableName string, keySpace string, columnName string) (string, error) {
+	pkColumns, err := c.GetPkByTableName(tableName, keySpace)
+	if err != nil {
+		return "", err
+	}
+	for _, col := range pkColumns {
+		if col.ColumnName == columnName {
+			return col.KeyType, nil
+		}
+	}
+	return "", fmt.Errorf("column %s is not a primary key in table %s", columnName, tableName)
+}

--- a/cassandra-bigtable-proxy/schema-mapping/schema_mapping_test.go
+++ b/cassandra-bigtable-proxy/schema-mapping/schema_mapping_test.go
@@ -1,0 +1,568 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package schemaMapping
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/datastax/go-cassandra-native-protocol/datatype"
+	"github.com/datastax/go-cassandra-native-protocol/message"
+	"go.uber.org/zap"
+)
+
+var systemColumnFamily = "cf1"
+var tablesMetaData = map[string]map[string]map[string]*Column{
+	"keyspace": {"table1": {
+		"column1": {
+			CQLType:      "text",
+			ColumnName:   "column1",
+			IsPrimaryKey: false,
+			PkPrecedence: 0,
+			IsCollection: false,
+			Metadata: message.ColumnMetadata{
+				Keyspace: "test-keyspace",
+				Table:    "table1",
+				Name:     "column1",
+				Index:    int32(0),
+				Type:     datatype.Varchar,
+			},
+		},
+	}},
+}
+var expectedResponse = []*message.ColumnMetadata{
+	{Keyspace: "test-keyspace", Name: "column1", Table: "table1", Type: datatype.Varchar, Index: 0},
+}
+
+func TestSchemaMappingConfig_GetColumnType(t *testing.T) {
+	columnExistsArgs := struct {
+		tableName  string
+		columnName string
+	}{
+		tableName:  "table1",
+		columnName: "column1",
+	}
+
+	tableExistsArgs := struct {
+		tableName  string
+		columnName string
+	}{
+		tableName:  "table2",
+		columnName: "column2",
+	}
+
+	columnExistsInDifferentTableArgs := struct {
+		tableName  string
+		columnName string
+	}{
+		tableName:  "table1",
+		columnName: "column2",
+	}
+
+	columnExistsWant := &ColumnType{
+		IsPrimaryKey: false,
+		IsCollection: false,
+	}
+
+	tests := []struct {
+		name   string
+		fields SchemaMappingConfig
+		args   struct {
+			tableName  string
+			columnName string
+		}
+		want    *ColumnType
+		wantErr bool
+	}{
+		{
+			name: "Column exists",
+			fields: SchemaMappingConfig{
+				TablesMetaData:     tablesMetaData,
+				SystemColumnFamily: systemColumnFamily,
+			},
+			args:    columnExistsArgs,
+			want:    columnExistsWant,
+			wantErr: false,
+		},
+		{
+			name: "Table exists",
+			fields: SchemaMappingConfig{
+				TablesMetaData:     tablesMetaData,
+				SystemColumnFamily: systemColumnFamily,
+			},
+			args:    tableExistsArgs,
+			wantErr: true,
+		},
+		{
+			name: "Column exists in different table",
+			fields: SchemaMappingConfig{
+				TablesMetaData:     tablesMetaData,
+				SystemColumnFamily: systemColumnFamily,
+			},
+			args:    columnExistsInDifferentTableArgs,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.fields.GetColumnType(tt.args.tableName, tt.args.columnName, "keyspace")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetColumnType() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetColumnType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSchemaMappingConfig_GetMetadataForColumns(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields SchemaMappingConfig
+		args   struct {
+			tableName   string
+			columnNames []string
+		}
+		want    []*message.ColumnMetadata
+		wantErr bool
+	}{
+		{
+			name: "column exists",
+			fields: SchemaMappingConfig{
+				TablesMetaData: map[string]map[string]map[string]*Column{
+					"keyspace": {"table1": {}},
+				},
+				SystemColumnFamily: "cf1",
+			},
+			args: struct {
+				tableName   string
+				columnNames []string
+			}{
+				tableName:   "table1",
+				columnNames: []string{"bigtable_ttl_ts"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "column exists",
+			fields: SchemaMappingConfig{
+				TablesMetaData:     tablesMetaData,
+				SystemColumnFamily: "cf1",
+			},
+			args: struct {
+				tableName   string
+				columnNames []string
+			}{
+				tableName:   "table1",
+				columnNames: []string{"bigtable_ttl_ts"},
+			},
+			want: []*message.ColumnMetadata{
+				{Keyspace: "test-keyspace", Name: "bigtable_ttl_ts", Table: "table1", Type: datatype.Int, Index: 0},
+			},
+			wantErr: false,
+		},
+		{
+			name: "column exists",
+			fields: SchemaMappingConfig{
+				TablesMetaData:     tablesMetaData,
+				SystemColumnFamily: "cf1",
+			},
+			args: struct {
+				tableName   string
+				columnNames []string
+			}{
+				tableName:   "table1",
+				columnNames: []string{"column1"},
+			},
+			want:    expectedResponse,
+			wantErr: false,
+		},
+		{
+			name: "column not exists",
+			fields: SchemaMappingConfig{
+				Logger:             zap.NewNop(),
+				TablesMetaData:     tablesMetaData,
+				SystemColumnFamily: "cf1",
+			},
+			args: struct {
+				tableName   string
+				columnNames []string
+			}{
+				tableName:   "table2",
+				columnNames: []string{"column1"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty column input",
+			fields: SchemaMappingConfig{
+				Logger:             zap.NewNop(),
+				TablesMetaData:     tablesMetaData,
+				SystemColumnFamily: "cf1",
+			},
+			args: struct {
+				tableName   string
+				columnNames []string
+			}{
+				tableName:   "table1",
+				columnNames: []string{},
+			},
+			want:    expectedResponse,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.fields.GetMetadataForColumns(tt.args.tableName, tt.args.columnNames, "keyspace")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetMetadataForColumns() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetMetadataForColumns() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSchemaMappingConfig_GetMetadataForSelectedColumns(t *testing.T) {
+	logger := zap.NewNop()
+
+	tests := []struct {
+		name   string
+		fields SchemaMappingConfig
+		args   struct {
+			tableName   string
+			columnNames []SelectedColumns
+			keySpace    string
+		}
+		want    []*message.ColumnMetadata
+		wantErr bool
+	}{
+		{
+			name: "Successfully retrieve metadata for specific column",
+			fields: SchemaMappingConfig{
+				Logger:         logger,
+				TablesMetaData: tablesMetaData,
+			},
+			args: struct {
+				tableName   string
+				columnNames []SelectedColumns
+				keySpace    string
+			}{
+				tableName:   "table1",
+				columnNames: []SelectedColumns{{Name: "column1"}},
+				keySpace:    "keyspace",
+			},
+			want:    expectedResponse,
+			wantErr: false,
+		},
+		{
+			name: "Return all columns when no specific columns provided",
+			fields: SchemaMappingConfig{
+				Logger:         logger,
+				TablesMetaData: tablesMetaData,
+			},
+			args: struct {
+				tableName   string
+				columnNames []SelectedColumns
+				keySpace    string
+			}{
+				tableName:   "table1",
+				columnNames: []SelectedColumns{},
+				keySpace:    "keyspace",
+			},
+			want:    expectedResponse,
+			wantErr: false,
+		},
+		{
+			name: "Error when table is not found",
+			fields: SchemaMappingConfig{
+				Logger:         logger,
+				TablesMetaData: tablesMetaData,
+			},
+			args: struct {
+				tableName   string
+				columnNames []SelectedColumns
+				keySpace    string
+			}{
+				tableName:   "nonexistent_table",
+				columnNames: []SelectedColumns{{Name: "column1"}},
+				keySpace:    "keyspace",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Error when column is not found",
+			fields: SchemaMappingConfig{
+				Logger:         logger,
+				TablesMetaData: tablesMetaData,
+			},
+			args: struct {
+				tableName   string
+				columnNames []SelectedColumns
+				keySpace    string
+			}{
+				tableName:   "table1",
+				columnNames: []SelectedColumns{{Name: "nonexistent_column"}},
+				keySpace:    "keyspace",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.fields.GetMetadataForSelectedColumns(tt.args.tableName, tt.args.columnNames, tt.args.keySpace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetMetadataForSelectedColumns() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetMetadataForSelectedColumns() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetPkByTableName(t *testing.T) {
+	logger := zap.NewNop()
+
+	// Sample data for testing
+	pkMetadataCache := map[string]map[string][]Column{
+		"keyspace1": {
+			"table1": {
+				{
+					CQLType:      "text",
+					ColumnName:   "id",
+					ColumnType:   "testColumn",
+					IsPrimaryKey: true,
+					PkPrecedence: 1,
+					IsCollection: false,
+				},
+			},
+		},
+	}
+
+	expectedPkResponse := []Column{
+		{
+			CQLType:      "text",
+			ColumnName:   "id",
+			ColumnType:   "testColumn",
+			IsPrimaryKey: true,
+			PkPrecedence: 1,
+			IsCollection: false,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		fields SchemaMappingConfig
+		args   struct {
+			tableName string
+			keySpace  string
+		}
+		want    []Column
+		wantErr bool
+	}{
+		{
+			name: "Successfully retrieve primary key metadata for table",
+			fields: SchemaMappingConfig{
+				Logger:          logger,
+				PkMetadataCache: pkMetadataCache,
+			},
+			args: struct {
+				tableName string
+				keySpace  string
+			}{
+				tableName: "table1",
+				keySpace:  "keyspace1",
+			},
+			want:    expectedPkResponse,
+			wantErr: false,
+		},
+		{
+			name: "Error when table metadata is not found",
+			fields: SchemaMappingConfig{
+				Logger:          logger,
+				PkMetadataCache: pkMetadataCache,
+			},
+			args: struct {
+				tableName string
+				keySpace  string
+			}{
+				tableName: "nonexistent_table",
+				keySpace:  "keyspace1",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Error when keyspace metadata is not found",
+			fields: SchemaMappingConfig{
+				Logger:          logger,
+				PkMetadataCache: pkMetadataCache,
+			},
+			args: struct {
+				tableName string
+				keySpace  string
+			}{
+				tableName: "table1",
+				keySpace:  "nonexistent_keyspace",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.fields.GetPkByTableName(tt.args.tableName, tt.args.keySpace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetPkByTableName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetPkByTableName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+func TestGetPkKeyType(t *testing.T) {
+	logger := zap.NewNop()
+
+	// Sample data for testing
+	pkMetadataCache := map[string]map[string][]Column{
+		"keyspace1": {
+			"table1": {
+				{
+					ColumnName:   "id",
+					KeyType:      "partition",
+					IsPrimaryKey: true,
+				},
+				{
+					ColumnName:   "name",
+					KeyType:      "clustering",
+					IsPrimaryKey: true,
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		fields SchemaMappingConfig
+		args   struct {
+			tableName  string
+			keySpace   string
+			columnName string
+		}
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Successfully get partition key type",
+			fields: SchemaMappingConfig{
+				Logger:          logger,
+				PkMetadataCache: pkMetadataCache,
+			},
+			args: struct {
+				tableName  string
+				keySpace   string
+				columnName string
+			}{
+				tableName:  "table1",
+				keySpace:   "keyspace1",
+				columnName: "id",
+			},
+			want:    "partition",
+			wantErr: false,
+		},
+		{
+			name: "Successfully get clustering key type",
+			fields: SchemaMappingConfig{
+				Logger:          logger,
+				PkMetadataCache: pkMetadataCache,
+			},
+			args: struct {
+				tableName  string
+				keySpace   string
+				columnName string
+			}{
+				tableName:  "table1",
+				keySpace:   "keyspace1",
+				columnName: "name",
+			},
+			want:    "clustering",
+			wantErr: false,
+		},
+		{
+			name: "Error when column is not a primary key",
+			fields: SchemaMappingConfig{
+				Logger:          logger,
+				PkMetadataCache: pkMetadataCache,
+			},
+			args: struct {
+				tableName  string
+				keySpace   string
+				columnName string
+			}{
+				tableName:  "table1",
+				keySpace:   "keyspace1",
+				columnName: "nonexistent_column",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Error when table not found",
+			fields: SchemaMappingConfig{
+				Logger:          logger,
+				PkMetadataCache: pkMetadataCache,
+			},
+			args: struct {
+				tableName  string
+				keySpace   string
+				columnName string
+			}{
+				tableName:  "nonexistent_table",
+				keySpace:   "keyspace1",
+				columnName: "id",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.fields.GetPkKeyType(tt.args.tableName, tt.args.keySpace, tt.args.columnName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetPkKeyType() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetPkKeyType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cassandra-bigtable-proxy/schema-mapping/schema_mapping_test.go
+++ b/cassandra-bigtable-proxy/schema-mapping/schema_mapping_test.go
@@ -16,11 +16,13 @@
 package schemaMapping
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/datastax/go-cassandra-native-protocol/datatype"
 	"github.com/datastax/go-cassandra-native-protocol/message"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )
 
@@ -47,7 +49,7 @@ var expectedResponse = []*message.ColumnMetadata{
 	{Keyspace: "test-keyspace", Name: "column1", Table: "table1", Type: datatype.Varchar, Index: 0},
 }
 
-func TestSchemaMappingConfig_GetColumnType(t *testing.T) {
+func Test_GetColumnType(t *testing.T) {
 	columnExistsArgs := struct {
 		tableName  string
 		columnName string
@@ -72,7 +74,7 @@ func TestSchemaMappingConfig_GetColumnType(t *testing.T) {
 		columnName: "column2",
 	}
 
-	columnExistsWant := &ColumnType{
+	columnExistsWant := &Column{
 		IsPrimaryKey: false,
 		IsCollection: false,
 	}
@@ -84,7 +86,7 @@ func TestSchemaMappingConfig_GetColumnType(t *testing.T) {
 			tableName  string
 			columnName string
 		}
-		want    *ColumnType
+		want    *Column
 		wantErr bool
 	}{
 		{
@@ -119,7 +121,7 @@ func TestSchemaMappingConfig_GetColumnType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.fields.GetColumnType(tt.args.tableName, tt.args.columnName, "keyspace")
+			got, err := tt.fields.GetColumnType("keyspace", tt.args.tableName, tt.args.columnName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetColumnType() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -131,7 +133,9 @@ func TestSchemaMappingConfig_GetColumnType(t *testing.T) {
 	}
 }
 
-func TestSchemaMappingConfig_GetMetadataForColumns(t *testing.T) {
+func Test_GetMetadataForColumns(t *testing.T) {
+	logger := zap.NewNop()
+
 	tests := []struct {
 		name   string
 		fields SchemaMappingConfig
@@ -143,43 +147,9 @@ func TestSchemaMappingConfig_GetMetadataForColumns(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "column exists",
+			name: "Success - Single regular column",
 			fields: SchemaMappingConfig{
-				TablesMetaData: map[string]map[string]map[string]*Column{
-					"keyspace": {"table1": {}},
-				},
-				SystemColumnFamily: "cf1",
-			},
-			args: struct {
-				tableName   string
-				columnNames []string
-			}{
-				tableName:   "table1",
-				columnNames: []string{"bigtable_ttl_ts"},
-			},
-			wantErr: true,
-		},
-		{
-			name: "column exists",
-			fields: SchemaMappingConfig{
-				TablesMetaData:     tablesMetaData,
-				SystemColumnFamily: "cf1",
-			},
-			args: struct {
-				tableName   string
-				columnNames []string
-			}{
-				tableName:   "table1",
-				columnNames: []string{"bigtable_ttl_ts"},
-			},
-			want: []*message.ColumnMetadata{
-				{Keyspace: "test-keyspace", Name: "bigtable_ttl_ts", Table: "table1", Type: datatype.Int, Index: 0},
-			},
-			wantErr: false,
-		},
-		{
-			name: "column exists",
-			fields: SchemaMappingConfig{
+				Logger:             logger,
 				TablesMetaData:     tablesMetaData,
 				SystemColumnFamily: "cf1",
 			},
@@ -194,9 +164,42 @@ func TestSchemaMappingConfig_GetMetadataForColumns(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "column not exists",
+			name: "Success - Multiple regular columns",
 			fields: SchemaMappingConfig{
-				Logger:             zap.NewNop(),
+				Logger: logger,
+				TablesMetaData: map[string]map[string]map[string]*Column{
+					"keyspace": {"table1": {
+						"column1": {
+							Metadata: message.ColumnMetadata{
+								Type: datatype.Varchar,
+							},
+						},
+						"column2": {
+							Metadata: message.ColumnMetadata{
+								Type: datatype.Int,
+							},
+						},
+					}},
+				},
+				SystemColumnFamily: "cf1",
+			},
+			args: struct {
+				tableName   string
+				columnNames []string
+			}{
+				tableName:   "table1",
+				columnNames: []string{"column1", "column2"},
+			},
+			want: []*message.ColumnMetadata{
+				{Type: datatype.Varchar, Index: 0},
+				{Type: datatype.Int, Index: 1},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Success - Special column (LimitValue)",
+			fields: SchemaMappingConfig{
+				Logger:             logger,
 				TablesMetaData:     tablesMetaData,
 				SystemColumnFamily: "cf1",
 			},
@@ -204,13 +207,78 @@ func TestSchemaMappingConfig_GetMetadataForColumns(t *testing.T) {
 				tableName   string
 				columnNames []string
 			}{
-				tableName:   "table2",
-				columnNames: []string{"column1"},
+				tableName:   "table1",
+				columnNames: []string{LimitValue},
 			},
+			want: []*message.ColumnMetadata{
+				{
+					Type:  datatype.Bigint,
+					Index: 0,
+					Name:  LimitValue,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Success - Mixed column types",
+			fields: SchemaMappingConfig{
+				Logger:             logger,
+				TablesMetaData:     tablesMetaData,
+				SystemColumnFamily: "cf1",
+			},
+			args: struct {
+				tableName   string
+				columnNames []string
+			}{
+				tableName:   "table1",
+				columnNames: []string{"column1", LimitValue},
+			},
+			want: []*message.ColumnMetadata{
+				{Type: datatype.Varchar, Index: 0, Name: "column1"},
+				{
+					Type:  datatype.Bigint,
+					Index: 1,
+					Name:  LimitValue,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Error - Column not found in metadata",
+			fields: SchemaMappingConfig{
+				Logger:             logger,
+				TablesMetaData:     tablesMetaData,
+				SystemColumnFamily: "cf1",
+			},
+			args: struct {
+				tableName   string
+				columnNames []string
+			}{
+				tableName:   "table1",
+				columnNames: []string{"nonexistent_column"},
+			},
+			want:    nil,
 			wantErr: true,
 		},
 		{
-			name: "empty column input",
+			name: "Error - Table not found",
+			fields: SchemaMappingConfig{
+				Logger:             logger,
+				TablesMetaData:     tablesMetaData,
+				SystemColumnFamily: "cf1",
+			},
+			args: struct {
+				tableName   string
+				columnNames []string
+			}{
+				tableName:   "nonexistent_table",
+				columnNames: []string{"column1"},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Empty column names",
 			fields: SchemaMappingConfig{
 				Logger:             zap.NewNop(),
 				TablesMetaData:     tablesMetaData,
@@ -226,23 +294,62 @@ func TestSchemaMappingConfig_GetMetadataForColumns(t *testing.T) {
 			want:    expectedResponse,
 			wantErr: false,
 		},
+		{
+			name: "Success - Multiple special columns",
+			fields: SchemaMappingConfig{
+				Logger:             logger,
+				TablesMetaData:     tablesMetaData,
+				SystemColumnFamily: "cf1",
+			},
+			args: struct {
+				tableName   string
+				columnNames []string
+			}{
+				tableName:   "table1",
+				columnNames: []string{LimitValue, LimitValue},
+			},
+			want: []*message.ColumnMetadata{
+				{
+					Type:  datatype.Bigint,
+					Index: 0,
+					Name:  LimitValue,
+				},
+				{
+					Type:  datatype.Bigint,
+					Index: 1,
+					Name:  LimitValue,
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.fields.GetMetadataForColumns(tt.args.tableName, tt.args.columnNames, "keyspace")
+			got, err := tt.fields.GetMetadataForColumns("keyspace", tt.args.tableName, tt.args.columnNames)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetMetadataForColumns() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetMetadataForColumns() = %v, want %v", got, tt.want)
+
+			// Compare metadata content instead of memory addresses
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
+				assert.Equal(t, len(tt.want), len(got))
+
+				for i, expected := range tt.want {
+					assert.Equal(t, expected.Type, got[i].Type)
+					assert.Equal(t, expected.Index, got[i].Index)
+					assert.Equal(t, expected.Name, got[i].Name)
+				}
 			}
 		})
 	}
 }
 
-func TestSchemaMappingConfig_GetMetadataForSelectedColumns(t *testing.T) {
+func Test_GetMetadataForSelectedColumns(t *testing.T) {
 	logger := zap.NewNop()
 
 	tests := []struct {
@@ -344,7 +451,7 @@ func TestSchemaMappingConfig_GetMetadataForSelectedColumns(t *testing.T) {
 	}
 }
 
-func TestGetPkByTableName(t *testing.T) {
+func Test_GetPkByTableName(t *testing.T) {
 	logger := zap.NewNop()
 
 	// Sample data for testing
@@ -447,7 +554,7 @@ func TestGetPkByTableName(t *testing.T) {
 		})
 	}
 }
-func TestGetPkKeyType(t *testing.T) {
+func Test_GetPkKeyType(t *testing.T) {
 	logger := zap.NewNop()
 
 	// Sample data for testing
@@ -563,6 +670,1171 @@ func TestGetPkKeyType(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("GetPkKeyType() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func Test_HandleSpecialColumn(t *testing.T) {
+	tests := []struct {
+		name                string
+		columnsMap          map[string]*Column
+		columnName          string
+		index               int32
+		isWriteTimeFunction bool
+		expectedMetadata    *message.ColumnMetadata
+		expectedError       error
+	}{
+		{
+			name: "Success - Special column (LimitValue)",
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Varchar,
+					},
+				},
+			},
+			columnName:          LimitValue,
+			index:               0,
+			isWriteTimeFunction: false,
+			expectedMetadata: &message.ColumnMetadata{
+				Type:  datatype.Bigint,
+				Index: 0,
+				Name:  LimitValue,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Write time function",
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Varchar,
+					},
+				},
+			},
+			columnName:          "writetime(column1)",
+			index:               1,
+			isWriteTimeFunction: true,
+			expectedMetadata: &message.ColumnMetadata{
+				Type:  datatype.Bigint,
+				Index: 1,
+				Name:  "writetime(column1)",
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Error - Invalid special column",
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Varchar,
+					},
+				},
+			},
+			columnName:          "invalid_column",
+			index:               0,
+			isWriteTimeFunction: false,
+			expectedMetadata:    nil,
+			expectedError:       fmt.Errorf("invalid special column: invalid_column"),
+		},
+		{
+			name:                "Error - Empty columns map",
+			columnsMap:          map[string]*Column{},
+			columnName:          LimitValue,
+			index:               0,
+			isWriteTimeFunction: false,
+			expectedMetadata:    nil,
+			expectedError:       fmt.Errorf("special column %s not found in provided metadata", LimitValue),
+		},
+		{
+			name: "Success - Multiple columns in map",
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Varchar,
+					},
+				},
+				"column2": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Int,
+					},
+				},
+			},
+			columnName:          LimitValue,
+			index:               2,
+			isWriteTimeFunction: false,
+			expectedMetadata: &message.ColumnMetadata{
+				Type:  datatype.Bigint,
+				Index: 2,
+				Name:  LimitValue,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Write time function with different column name",
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Varchar,
+					},
+				},
+			},
+			columnName:          "writetime(column2)",
+			index:               3,
+			isWriteTimeFunction: true,
+			expectedMetadata: &message.ColumnMetadata{
+				Type:  datatype.Bigint,
+				Index: 3,
+				Name:  "writetime(column2)",
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &SchemaMappingConfig{}
+			metadata, err := config.handleSpecialColumn(tt.columnsMap, tt.columnName, tt.index, tt.isWriteTimeFunction)
+
+			// Check error cases
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+				assert.Nil(t, metadata)
+				return
+			}
+
+			// Check success cases
+			assert.NoError(t, err)
+			assert.NotNil(t, metadata)
+			assert.Equal(t, tt.expectedMetadata.Type, metadata.Type)
+			assert.Equal(t, tt.expectedMetadata.Index, metadata.Index)
+			assert.Equal(t, tt.expectedMetadata.Name, metadata.Name)
+		})
+	}
+}
+
+func Test_InstanceExists(t *testing.T) {
+	tests := []struct {
+		name     string
+		fields   SchemaMappingConfig
+		keyspace string
+		want     bool
+	}{
+		{
+			name: "Keyspace exists",
+			fields: SchemaMappingConfig{
+				TablesMetaData: map[string]map[string]map[string]*Column{
+					"test_keyspace": {
+						"table1": {
+							"column1": {
+								CQLType:      "text",
+								ColumnName:   "column1",
+								IsPrimaryKey: false,
+							},
+						},
+					},
+				},
+			},
+			keyspace: "test_keyspace",
+			want:     true,
+		},
+		{
+			name: "Keyspace does not exist",
+			fields: SchemaMappingConfig{
+				TablesMetaData: map[string]map[string]map[string]*Column{
+					"test_keyspace": {
+						"table1": {
+							"column1": {
+								CQLType:      "text",
+								ColumnName:   "column1",
+								IsPrimaryKey: false,
+							},
+						},
+					},
+				},
+			},
+			keyspace: "nonexistent_keyspace",
+			want:     false,
+		},
+		{
+			name: "Empty TablesMetaData",
+			fields: SchemaMappingConfig{
+				TablesMetaData: map[string]map[string]map[string]*Column{},
+			},
+			keyspace: "any_keyspace",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.fields.InstanceExists(tt.keyspace)
+			if got != tt.want {
+				t.Errorf("InstanceExists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_TableExist(t *testing.T) {
+	tests := []struct {
+		name      string
+		fields    SchemaMappingConfig
+		keyspace  string
+		tableName string
+		want      bool
+	}{
+		{
+			name: "Table exists in keyspace",
+			fields: SchemaMappingConfig{
+				TablesMetaData: map[string]map[string]map[string]*Column{
+					"test_keyspace": {
+						"table1": {
+							"column1": {
+								CQLType:      "text",
+								ColumnName:   "column1",
+								IsPrimaryKey: false,
+							},
+						},
+					},
+				},
+			},
+			keyspace:  "test_keyspace",
+			tableName: "table1",
+			want:      true,
+		},
+		{
+			name: "Table does not exist in keyspace",
+			fields: SchemaMappingConfig{
+				TablesMetaData: map[string]map[string]map[string]*Column{
+					"test_keyspace": {
+						"table1": {
+							"column1": {
+								CQLType:      "text",
+								ColumnName:   "column1",
+								IsPrimaryKey: false,
+							},
+						},
+					},
+				},
+			},
+			keyspace:  "test_keyspace",
+			tableName: "nonexistent_table",
+			want:      false,
+		},
+		{
+			name: "Keyspace does not exist",
+			fields: SchemaMappingConfig{
+				TablesMetaData: map[string]map[string]map[string]*Column{
+					"test_keyspace": {
+						"table1": {
+							"column1": {
+								CQLType:      "text",
+								ColumnName:   "column1",
+								IsPrimaryKey: false,
+							},
+						},
+					},
+				},
+			},
+			keyspace:  "nonexistent_keyspace",
+			tableName: "table1",
+			want:      false,
+		},
+		{
+			name: "Empty TablesMetaData",
+			fields: SchemaMappingConfig{
+				TablesMetaData: map[string]map[string]map[string]*Column{},
+			},
+			keyspace:  "any_keyspace",
+			tableName: "any_table",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.fields.TableExist(tt.keyspace, tt.tableName)
+			if got != tt.want {
+				t.Errorf("TableExist() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_GetSpecificColumnsMetadataForSelectedColumns(t *testing.T) {
+	logger := zap.NewNop()
+
+	tests := []struct {
+		name          string
+		fields        SchemaMappingConfig
+		columnsMap    map[string]*Column
+		selectedCols  []SelectedColumns
+		tableName     string
+		expectedMeta  []*message.ColumnMetadata
+		expectedError error
+	}{
+		{
+			name: "Success - Regular column",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "test_keyspace",
+						Table:    "test_table",
+						Name:     "column1",
+						Type:     datatype.Varchar,
+						Index:    0,
+					},
+				},
+			},
+			selectedCols: []SelectedColumns{
+				{
+					Name: "column1",
+				},
+			},
+			tableName: "test_table",
+			expectedMeta: []*message.ColumnMetadata{
+				{
+					Keyspace: "test_keyspace",
+					Table:    "test_table",
+					Name:     "column1",
+					Type:     datatype.Varchar,
+					Index:    0,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Write time column",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "test_keyspace",
+						Table:    "test_table",
+						Name:     "column1",
+						Type:     datatype.Varchar,
+						Index:    0,
+					},
+				},
+			},
+			selectedCols: []SelectedColumns{
+				{
+					Name:              "writetime_column",
+					IsWriteTimeColumn: true,
+					WriteTimeColumn:   "column1",
+				},
+			},
+			tableName: "test_table",
+			expectedMeta: []*message.ColumnMetadata{
+				{
+					Keyspace: "test_keyspace",
+					Table:    "test_table",
+					Name:     "writetime(column1)",
+					Type:     datatype.Bigint,
+					Index:    0,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Special column",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "test_keyspace",
+						Table:    "test_table",
+						Name:     "column1",
+						Type:     datatype.Varchar,
+						Index:    0,
+					},
+				},
+			},
+			selectedCols: []SelectedColumns{
+				{
+					Name: LimitValue,
+				},
+			},
+			tableName: "test_table",
+			expectedMeta: []*message.ColumnMetadata{
+				{
+					Keyspace: "test_keyspace",
+					Table:    "test_table",
+					Name:     LimitValue,
+					Type:     datatype.Bigint,
+					Index:    0,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Function call",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "test_keyspace",
+						Table:    "test_table",
+						Name:     "column1",
+						Type:     datatype.Varchar,
+						Index:    0,
+					},
+				},
+			},
+			selectedCols: []SelectedColumns{
+				{
+					Name:   "column1",
+					IsFunc: true,
+				},
+			},
+			tableName:     "test_table",
+			expectedMeta:  nil,
+			expectedError: nil,
+		},
+		{
+			name: "Error - Column not found",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "test_keyspace",
+						Table:    "test_table",
+						Name:     "column1",
+						Type:     datatype.Varchar,
+						Index:    0,
+					},
+				},
+			},
+			selectedCols: []SelectedColumns{
+				{
+					Name: "nonexistent_column",
+				},
+			},
+			tableName:     "test_table",
+			expectedMeta:  nil,
+			expectedError: fmt.Errorf("metadata not found for the `nonexistent_column` column in `test_table`table"),
+		},
+		{
+			name: "Error - Invalid special column",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "test_keyspace",
+						Table:    "test_table",
+						Name:     "column1",
+						Type:     datatype.Varchar,
+						Index:    0,
+					},
+				},
+			},
+			selectedCols: []SelectedColumns{
+				{
+					Name: "invalid_special_column",
+				},
+			},
+			tableName:     "test_table",
+			expectedMeta:  nil,
+			expectedError: fmt.Errorf("metadata not found for the `invalid_special_column` column in `test_table`table"),
+		},
+		{
+			name: "Error - Empty columns map",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{},
+			selectedCols: []SelectedColumns{
+				{
+					Name: "column1",
+				},
+			},
+			tableName:     "test_table",
+			expectedMeta:  nil,
+			expectedError: fmt.Errorf("metadata not found for the `column1` column in `test_table`table"),
+		},
+		{
+			name: "Error - Write time column not found",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{},
+			selectedCols: []SelectedColumns{
+				{
+					Name:              "no_write_time_column",
+					IsWriteTimeColumn: true,
+					WriteTimeColumn:   "nonexistent_column",
+				},
+			},
+			tableName:     "test_table",
+			expectedMeta:  nil,
+			expectedError: fmt.Errorf("special column writetime(nonexistent_column) not found in provided metadata"),
+		},
+		{
+			name: "Error - Special column handling error",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{},
+			selectedCols: []SelectedColumns{
+				{
+					Name: LimitValue,
+				},
+			},
+			tableName:     "test_table",
+			expectedMeta:  nil,
+			expectedError: fmt.Errorf("special column %s not found in provided metadata", LimitValue),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata, err := tt.fields.getSpecificColumnsMetadataForSelectedColumns(tt.columnsMap, tt.selectedCols, tt.tableName)
+
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+				assert.Nil(t, metadata)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, metadata)
+
+			// Compare metadata entries only for success cases
+			for i, expected := range tt.expectedMeta {
+				assert.Equal(t, expected.Keyspace, metadata[i].Keyspace)
+				assert.Equal(t, expected.Table, metadata[i].Table)
+				assert.Equal(t, expected.Name, metadata[i].Name)
+				assert.Equal(t, expected.Type, metadata[i].Type)
+				assert.Equal(t, expected.Index, metadata[i].Index)
+			}
+		})
+	}
+}
+
+func Test_GetSpecificColumnsMetadata(t *testing.T) {
+	logger := zap.NewNop()
+
+	tests := []struct {
+		name          string
+		fields        SchemaMappingConfig
+		columnsMap    map[string]*Column
+		columnNames   []string
+		tableName     string
+		expectedMeta  []*message.ColumnMetadata
+		expectedError error
+	}{
+		{
+			name: "Success - Regular column",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Varchar,
+					},
+				},
+			},
+			columnNames: []string{"column1"},
+			tableName:   "table1",
+			expectedMeta: []*message.ColumnMetadata{
+				{
+					Type:  datatype.Varchar,
+					Index: 0,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Special column (LimitValue)",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Varchar,
+					},
+				},
+			},
+			columnNames: []string{LimitValue},
+			tableName:   "table1",
+			expectedMeta: []*message.ColumnMetadata{
+				{
+					Type:  datatype.Bigint,
+					Index: 0,
+					Name:  LimitValue,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Multiple columns",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Varchar,
+					},
+				},
+				"column2": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Int,
+					},
+				},
+			},
+			columnNames: []string{"column1", "column2"},
+			tableName:   "table1",
+			expectedMeta: []*message.ColumnMetadata{
+				{
+					Type:  datatype.Varchar,
+					Index: 0,
+				},
+				{
+					Type:  datatype.Int,
+					Index: 1,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Mixed column types",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Varchar,
+					},
+				},
+			},
+			columnNames: []string{"column1", LimitValue},
+			tableName:   "table1",
+			expectedMeta: []*message.ColumnMetadata{
+				{
+					Type:  datatype.Varchar,
+					Index: 0,
+				},
+				{
+					Type:  datatype.Bigint,
+					Index: 1,
+					Name:  LimitValue,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Error - Column not found",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Varchar,
+					},
+				},
+			},
+			columnNames:   []string{"nonexistent_column"},
+			tableName:     "table1",
+			expectedMeta:  nil,
+			expectedError: fmt.Errorf("metadata not found for the `nonexistent_column` column in `table1`table"),
+		},
+		{
+			name: "Success - Empty column names",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Varchar,
+					},
+				},
+			},
+			columnNames:   []string{},
+			tableName:     "table1",
+			expectedMeta:  nil,
+			expectedError: nil,
+		},
+		{
+			name: "Success - Multiple special columns",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Type: datatype.Varchar,
+					},
+				},
+			},
+			columnNames: []string{LimitValue, LimitValue},
+			tableName:   "table1",
+			expectedMeta: []*message.ColumnMetadata{
+				{
+					Type:  datatype.Bigint,
+					Index: 0,
+					Name:  LimitValue,
+				},
+				{
+					Type:  datatype.Bigint,
+					Index: 1,
+					Name:  LimitValue,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Error - Special column handling error",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap:    map[string]*Column{},
+			columnNames:   []string{LimitValue},
+			tableName:     "test_table",
+			expectedMeta:  nil,
+			expectedError: fmt.Errorf("special column %s not found in provided metadata", LimitValue),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata, err := tt.fields.getSpecificColumnsMetadata(tt.columnsMap, tt.columnNames, tt.tableName)
+
+			// Check error cases
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.Equal(t, tt.expectedError.Error(), err.Error())
+				assert.Nil(t, metadata)
+				return
+			}
+
+			// Check success cases
+			assert.NoError(t, err)
+			if tt.expectedMeta == nil {
+				assert.Nil(t, metadata)
+			} else {
+				assert.NotNil(t, metadata)
+				assert.Equal(t, len(tt.expectedMeta), len(metadata))
+
+				// Create maps to store metadata by name for comparison
+				expectedMap := make(map[string]*message.ColumnMetadata)
+				actualMap := make(map[string]*message.ColumnMetadata)
+
+				// Populate the maps
+				for _, meta := range tt.expectedMeta {
+					expectedMap[meta.Name] = meta
+				}
+				for _, meta := range metadata {
+					actualMap[meta.Name] = meta
+				}
+
+				// Compare metadata entries by name
+				for name, expected := range expectedMap {
+					actual, exists := actualMap[name]
+					assert.True(t, exists, "Expected metadata for column %s not found", name)
+					assert.Equal(t, expected.Keyspace, actual.Keyspace)
+					assert.Equal(t, expected.Table, actual.Table)
+					assert.Equal(t, expected.Type, actual.Type)
+					// Don't compare indices as they are order-dependent
+				}
+			}
+		})
+	}
+}
+
+func Test_CloneColumnMetadata(t *testing.T) {
+	tests := []struct {
+		name          string
+		metadata      *message.ColumnMetadata
+		index         int32
+		expectedMeta  *message.ColumnMetadata
+		expectedError error
+	}{
+		{
+			name: "Success - Basic metadata cloning",
+			metadata: &message.ColumnMetadata{
+				Keyspace: "test_keyspace",
+				Table:    "test_table",
+				Name:     "test_column",
+				Type:     datatype.Varchar,
+				Index:    0,
+			},
+			index: 1,
+			expectedMeta: &message.ColumnMetadata{
+				Keyspace: "test_keyspace",
+				Table:    "test_table",
+				Name:     "test_column",
+				Type:     datatype.Varchar,
+				Index:    1,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Metadata with all fields",
+			metadata: &message.ColumnMetadata{
+				Keyspace: "test_keyspace",
+				Table:    "test_table",
+				Name:     "test_column",
+				Type:     datatype.Int,
+				Index:    5,
+			},
+			index: 10,
+			expectedMeta: &message.ColumnMetadata{
+				Keyspace: "test_keyspace",
+				Table:    "test_table",
+				Name:     "test_column",
+				Type:     datatype.Int,
+				Index:    10,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Metadata with array type",
+			metadata: &message.ColumnMetadata{
+				Keyspace: "test_keyspace",
+				Table:    "test_table",
+				Name:     "test_array",
+				Type:     datatype.Varchar,
+				Index:    0,
+			},
+			index: 2,
+			expectedMeta: &message.ColumnMetadata{
+				Keyspace: "test_keyspace",
+				Table:    "test_table",
+				Name:     "test_array",
+				Type:     datatype.Varchar,
+				Index:    2,
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Metadata with null values",
+			metadata: &message.ColumnMetadata{
+				Keyspace: "",
+				Table:    "",
+				Name:     "",
+				Type:     datatype.Varchar,
+				Index:    0,
+			},
+			index: 4,
+			expectedMeta: &message.ColumnMetadata{
+				Keyspace: "",
+				Table:    "",
+				Name:     "",
+				Type:     datatype.Varchar,
+				Index:    4,
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &SchemaMappingConfig{}
+			result := config.cloneColumnMetadata(tt.metadata, tt.index)
+
+			// Verify the result is not nil
+			assert.NotNil(t, result)
+
+			// Compare all fields
+			assert.Equal(t, tt.expectedMeta.Keyspace, result.Keyspace)
+			assert.Equal(t, tt.expectedMeta.Table, result.Table)
+			assert.Equal(t, tt.expectedMeta.Name, result.Name)
+			assert.Equal(t, tt.expectedMeta.Type, result.Type)
+			assert.Equal(t, tt.expectedMeta.Index, result.Index)
+
+			// Verify that the original metadata was not modified
+			assert.Equal(t, tt.metadata.Index, tt.metadata.Index)
+		})
+	}
+}
+
+func Test_GetAllColumnsMetadata(t *testing.T) {
+	logger := zap.NewNop()
+
+	tests := []struct {
+		name          string
+		fields        SchemaMappingConfig
+		columnsMap    map[string]*Column
+		expectedMeta  []*message.ColumnMetadata
+		expectedError error
+	}{
+		{
+			name: "Success - Single column",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "test_keyspace",
+						Table:    "test_table",
+						Name:     "column1",
+						Type:     datatype.Varchar,
+						Index:    0,
+					},
+				},
+			},
+			expectedMeta: []*message.ColumnMetadata{
+				{
+					Keyspace: "test_keyspace",
+					Table:    "test_table",
+					Name:     "column1",
+					Type:     datatype.Varchar,
+					Index:    0,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Multiple columns with different types",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "test_keyspace",
+						Table:    "test_table",
+						Name:     "column1",
+						Type:     datatype.Varchar,
+						Index:    0,
+					},
+				},
+				"column2": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "test_keyspace",
+						Table:    "test_table",
+						Name:     "column2",
+						Type:     datatype.Int,
+						Index:    0,
+					},
+				},
+				"column3": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "test_keyspace",
+						Table:    "test_table",
+						Name:     "column3",
+						Type:     datatype.Boolean,
+						Index:    0,
+					},
+				},
+			},
+			expectedMeta: []*message.ColumnMetadata{
+				{
+					Keyspace: "test_keyspace",
+					Table:    "test_table",
+					Name:     "column1",
+					Type:     datatype.Varchar,
+					Index:    0,
+				},
+				{
+					Keyspace: "test_keyspace",
+					Table:    "test_table",
+					Name:     "column2",
+					Type:     datatype.Int,
+					Index:    1,
+				},
+				{
+					Keyspace: "test_keyspace",
+					Table:    "test_table",
+					Name:     "column3",
+					Type:     datatype.Boolean,
+					Index:    2,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Empty columns map",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap:    map[string]*Column{},
+			expectedMeta:  []*message.ColumnMetadata{},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Columns with collection types",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"list_column": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "test_keyspace",
+						Table:    "test_table",
+						Name:     "list_column",
+						Type:     datatype.Varchar,
+						Index:    0,
+					},
+				},
+				"map_column": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "test_keyspace",
+						Table:    "test_table",
+						Name:     "map_column",
+						Type:     datatype.Varchar,
+						Index:    0,
+					},
+				},
+			},
+			expectedMeta: []*message.ColumnMetadata{
+				{
+					Keyspace: "test_keyspace",
+					Table:    "test_table",
+					Name:     "list_column",
+					Type:     datatype.Varchar,
+					Index:    0,
+				},
+				{
+					Keyspace: "test_keyspace",
+					Table:    "test_table",
+					Name:     "map_column",
+					Type:     datatype.Varchar,
+					Index:    1,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "Success - Columns with null values",
+			fields: SchemaMappingConfig{
+				Logger: logger,
+			},
+			columnsMap: map[string]*Column{
+				"column1": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "",
+						Table:    "",
+						Name:     "",
+						Type:     datatype.Varchar,
+						Index:    0,
+					},
+				},
+				"column2": {
+					Metadata: message.ColumnMetadata{
+						Keyspace: "",
+						Table:    "",
+						Name:     "",
+						Type:     datatype.Int,
+						Index:    0,
+					},
+				},
+			},
+			expectedMeta: []*message.ColumnMetadata{
+				{
+					Keyspace: "",
+					Table:    "",
+					Name:     "",
+					Type:     datatype.Varchar,
+					Index:    0,
+				},
+				{
+					Keyspace: "",
+					Table:    "",
+					Name:     "",
+					Type:     datatype.Int,
+					Index:    1,
+				},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := tt.fields.getAllColumnsMetadata(tt.columnsMap)
+
+			// Check if the result is not nil (except for empty columns map case)
+			if len(tt.columnsMap) > 0 {
+				assert.NotNil(t, metadata)
+			}
+
+			// Check the length of the result
+			assert.Equal(t, len(tt.expectedMeta), len(metadata))
+
+			// Create maps to store metadata by name for comparison
+			expectedMap := make(map[string]*message.ColumnMetadata)
+			actualMap := make(map[string]*message.ColumnMetadata)
+
+			// Populate the maps
+			for _, meta := range tt.expectedMeta {
+				expectedMap[meta.Name] = meta
+			}
+			for _, meta := range metadata {
+				actualMap[meta.Name] = meta
+			}
+
+			// Compare metadata entries by name
+			for name, expected := range expectedMap {
+				actual, exists := actualMap[name]
+				assert.True(t, exists, "Expected metadata for column %s not found", name)
+				assert.Equal(t, expected.Keyspace, actual.Keyspace)
+				assert.Equal(t, expected.Table, actual.Table)
+			}
+		})
+	}
+}
+
+func Test_GetTimestampColumnName(t *testing.T) {
+	tests := []struct {
+		name       string
+		aliasName  string
+		columnName string
+		want       string
+	}{
+		{
+			name:       "Empty alias name",
+			aliasName:  "",
+			columnName: "column1",
+			want:       "writetime(column1)",
+		},
+		{
+			name:       "With alias name",
+			aliasName:  "alias_column",
+			columnName: "column1",
+			want:       "alias_column",
+		},
+		{
+			name:       "Empty alias and special character in column name",
+			aliasName:  "",
+			columnName: "user_id",
+			want:       "writetime(user_id)",
+		},
+		{
+			name:       "With alias containing special characters",
+			aliasName:  "wt_user_id",
+			columnName: "user_id",
+			want:       "wt_user_id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getTimestampColumnName(tt.aliasName, tt.columnName)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Add schema mapping and caching module for Cassandra to Bigtable proxy

- Implemented the `schema mapping` module to facilitate schema mapping between Cassandra and Bigtable
- Introduced schema caching for efficient reuse across the application
- Integrated schema caching for query conversion, data type conversion, and data transformation
- Ensured seamless compatibility between Cassandra and Bigtable for efficient query processing and data translation

This commit leverages for efficient query and data type conversions in the proxy integration.