### PR TITLE
Adding utilities module for common helper functions

### DIFF
--- a/cassandra-bigtable-proxy/utilities/utils.go
+++ b/cassandra-bigtable-proxy/utilities/utils.go
@@ -16,7 +16,6 @@
 package utilities
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -143,47 +142,6 @@ const (
 	Error = "error"
 	Warn  = "warn"
 )
-
-// formatTimestamp formats the Timestamp into time.
-func FormatTimestamp(ts int64) (*time.Time, error) {
-	if ts == 0 {
-		return nil, errors.New("no valid timestamp found")
-	}
-	var formattedValue time.Time
-	const secondsThreshold = int64(1e10)
-	const millisecondsThreshold = int64(1e13)
-	const microsecondsThreshold = int64(1e16)
-	const nanosecondsThreshold = int64(1e18)
-
-	switch {
-	case ts < secondsThreshold:
-
-		formattedValue = time.Unix(ts, 0)
-	case ts >= secondsThreshold && ts < millisecondsThreshold:
-		formattedValue = time.UnixMilli(ts)
-	case ts >= millisecondsThreshold && ts < microsecondsThreshold:
-		formattedValue = time.UnixMicro(ts)
-	case ts >= microsecondsThreshold && ts < nanosecondsThreshold:
-		seconds := ts / int64(time.Second)
-		// Get the remaining nanoseconds
-		nanoseconds := ts % int64(time.Second)
-		formattedValue = time.Unix(seconds, nanoseconds)
-	default:
-		return nil, errors.New("no valid timestamp found")
-	}
-
-	return &formattedValue, nil
-}
-
-// keyExists checks if a key is present in a list of strings.
-func KeyExistsInList(key string, list []string) bool {
-	for _, item := range list {
-		if item == key {
-			return true // Key found
-		}
-	}
-	return false // Key not found
-}
 
 // GetCassandraColumnType() converts a string representation of a Cassandra data type into
 // a corresponding DataType value. It supports a range of common Cassandra data types,

--- a/cassandra-bigtable-proxy/utilities/utils.go
+++ b/cassandra-bigtable-proxy/utilities/utils.go
@@ -1,0 +1,490 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package utilities
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/datastax/go-cassandra-native-protocol/datatype"
+	"github.com/datastax/go-cassandra-native-protocol/primitive"
+	"github.com/natefinch/lumberjack"
+	"github.com/ollionorg/cassandra-to-bigtable-proxy/collectiondecoder"
+	"github.com/ollionorg/cassandra-to-bigtable-proxy/proxycore"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const (
+	CustomWritetime = "writetime_"
+)
+
+type LoggerConfig struct {
+	OutputType string `yaml:"outputType"`
+	Filename   string `yaml:"fileName"`
+	MaxSize    int    `yaml:"maxSize"`    // megabytes
+	MaxBackups int    `yaml:"maxBackups"` // The value of MaxBackups determines how many previous log files are kept after a new log file is created due to the MaxSize or MaxAge limits.
+	MaxAge     int    `yaml:"maxAge"`     // days
+	Compress   bool   `yaml:"compress"`   // the rotated log files to be compressed to save disk space.
+}
+
+var (
+	MapOfStrToStr     = datatype.NewMapType(datatype.Varchar, datatype.Varchar)
+	MapOfStrToInt     = datatype.NewMapType(datatype.Varchar, datatype.Int)
+	MapOfStrToBigInt  = datatype.NewMapType(datatype.Varchar, datatype.Bigint)
+	MapOfStrToBool    = datatype.NewMapType(datatype.Varchar, datatype.Boolean)
+	MapOfStrToFloat   = datatype.NewMapType(datatype.Varchar, datatype.Float)
+	MapOfStrToDouble  = datatype.NewMapType(datatype.Varchar, datatype.Double)
+	MapOfStrToTime    = datatype.NewMapType(datatype.Varchar, datatype.Timestamp)
+	MapOfTimeToTime   = datatype.NewMapType(datatype.Timestamp, datatype.Timestamp)
+	MapOfTimeToStr    = datatype.NewMapType(datatype.Timestamp, datatype.Varchar)
+	MapOfTimeToInt    = datatype.NewMapType(datatype.Timestamp, datatype.Int)
+	MapOfTimeToBigInt = datatype.NewMapType(datatype.Timestamp, datatype.Bigint)
+	MapOfTimeToFloat  = datatype.NewMapType(datatype.Timestamp, datatype.Float)
+	MapOfTimeToDouble = datatype.NewMapType(datatype.Timestamp, datatype.Double)
+	MapOfTimeToBool   = datatype.NewMapType(datatype.Timestamp, datatype.Boolean)
+	SetOfStr          = datatype.NewSetType(datatype.Varchar)
+	SetOfInt          = datatype.NewSetType(datatype.Int)
+	SetOfBigInt       = datatype.NewSetType(datatype.Bigint)
+	SetOfBool         = datatype.NewSetType(datatype.Boolean)
+	SetOfFloat        = datatype.NewSetType(datatype.Float)
+	SetOfDouble       = datatype.NewSetType(datatype.Double)
+	SetOfTimeStamp    = datatype.NewSetType(datatype.Timestamp)
+	ListOfStr         = datatype.NewListType(datatype.Varchar)
+	ListOfBool        = datatype.NewListType(datatype.Boolean)
+	ListOfInt         = datatype.NewListType(datatype.Int)
+	ListOfBigInt      = datatype.NewListType(datatype.Bigint)
+	ListOfFloat       = datatype.NewListType(datatype.Float)
+	ListOfDouble      = datatype.NewListType(datatype.Double)
+	ListOfTimeStamp   = datatype.NewListType(datatype.Timestamp)
+)
+
+var (
+	EncodedTrue, _  = proxycore.EncodeType(datatype.Boolean, primitive.ProtocolVersion4, true)
+	EncodedFalse, _ = proxycore.EncodeType(datatype.Boolean, primitive.ProtocolVersion4, false)
+)
+
+// formatTimestamp formats the Timestamp into time.
+func FormatTimestamp(ts int64) (*time.Time, error) {
+	if ts == 0 {
+		return nil, errors.New("no valid timestamp found")
+	}
+	var formattedValue time.Time
+	const secondsThreshold = int64(1e10)
+	const millisecondsThreshold = int64(1e13)
+	const microsecondsThreshold = int64(1e16)
+	const nanosecondsThreshold = int64(1e18)
+
+	switch {
+	case ts < secondsThreshold:
+
+		formattedValue = time.Unix(ts, 0)
+	case ts >= secondsThreshold && ts < millisecondsThreshold:
+		formattedValue = time.UnixMilli(ts)
+	case ts >= millisecondsThreshold && ts < microsecondsThreshold:
+		formattedValue = time.UnixMicro(ts)
+	case ts >= microsecondsThreshold && ts < nanosecondsThreshold:
+		seconds := ts / int64(time.Second)
+		// Get the remaining nanoseconds
+		nanoseconds := ts % int64(time.Second)
+		formattedValue = time.Unix(seconds, nanoseconds)
+	default:
+		return nil, errors.New("no valid timestamp found")
+	}
+
+	return &formattedValue, nil
+}
+
+// keyExists checks if a key is present in a list of strings.
+func KeyExistsInList(key string, list []string) bool {
+	for _, item := range list {
+		if item == key {
+			return true // Key found
+		}
+	}
+	return false // Key not found
+}
+
+// GetCassandraColumnType() converts a string representation of a Cassandra data type into
+// a corresponding DataType value. It supports a range of common Cassandra data types,
+// including text, blob, timestamp, int, bigint, boolean, uuid, various map and list types.
+//
+// Parameters:
+//   - c: A string representing the Cassandra column data type. This function expects
+//     the data type in a specific format (e.g., "text", "int", "map<text, boolean>").
+//
+// Returns:
+//   - datatype.DataType: The corresponding DataType value for the provided string.
+//     This is used to represent the Cassandra data type in a structured format within Go.
+//   - error: An error is returned if the provided string does not match any of the known
+//     Cassandra data types. This helps in identifying unsupported or incorrectly specified
+//     data types.
+func GetCassandraColumnType(c string) (datatype.DataType, error) {
+	choice := strings.ToLower(strings.ReplaceAll(c, " ", ""))
+	switch choice {
+	case "text":
+		return datatype.Varchar, nil
+	case "blob":
+		return datatype.Blob, nil
+	case "timestamp":
+		return datatype.Timestamp, nil
+	case "int":
+		return datatype.Int, nil
+	case "bigint":
+		return datatype.Bigint, nil
+	case "boolean":
+		return datatype.Boolean, nil
+	case "uuid":
+		return datatype.Uuid, nil
+	case "float":
+		return datatype.Float, nil
+	case "double":
+		return datatype.Double, nil
+	case "map<text,boolean>":
+		return MapOfStrToBool, nil
+	case "map<text,int>":
+		return MapOfStrToInt, nil
+	case "map<text,bigint>":
+		return MapOfStrToBigInt, nil
+	case "map<text,float>":
+		return MapOfStrToFloat, nil
+	case "map<text,double>":
+		return MapOfStrToDouble, nil
+	case "map<text,text>":
+		return MapOfStrToStr, nil
+	case "map<text,timestamp>":
+		return MapOfStrToTime, nil
+	case "map<timestamp,text>":
+		return MapOfTimeToStr, nil
+	case "map<timestamp,boolean>":
+		return MapOfTimeToBool, nil
+	case "map<timestamp,float>":
+		return MapOfTimeToFloat, nil
+	case "map<timestamp,double>":
+		return MapOfTimeToDouble, nil
+	case "map<timestamp,bigint>":
+		return MapOfTimeToBigInt, nil
+	case "map<timestamp,int>":
+		return MapOfTimeToInt, nil
+	case "map<timestamp,timestamp>":
+		return MapOfTimeToTime, nil
+	case "list<text>", "frozen<list<text>>":
+		return datatype.NewListType(datatype.Varchar), nil
+	case "set<int>", "frozen<set<int>>":
+		return SetOfInt, nil
+	case "set<bigint>", "frozen<set<bigint>>":
+		return SetOfBigInt, nil
+	case "set<float>", "frozen<set<float>>":
+		return SetOfFloat, nil
+	case "set<double>", "frozen<set<double>>":
+		return SetOfDouble, nil
+	case "set<timestamp>", "frozen<set<timestamp>>":
+		return SetOfTimeStamp, nil
+	case "set<text>", "frozen<set<text>>":
+		return SetOfStr, nil
+	case "set<boolean>", "frozen<set<boolean>>":
+		return SetOfBool, nil
+	case "list<boolean>", "frozen<list<boolean>>":
+		return ListOfBool, nil
+	case "list<int>", "frozen<list<int>>":
+		return ListOfInt, nil
+	case "list<bigint>", "frozen<list<bigint>>":
+		return ListOfBigInt, nil
+	case "list<float>", "frozen<list<float>>":
+		return ListOfFloat, nil
+	case "list<double>", "frozen<list<double>>":
+		return ListOfDouble, nil
+	case "list<timestamp>", "frozen<list<timestamp>>":
+		return ListOfTimeStamp, nil
+
+	default:
+		return nil, fmt.Errorf("%s", "Error in returning column type")
+	}
+}
+
+// DecodeEncodedValues() Function used to decode the encoded values into its original format
+func DecodeEncodedValues(value []byte, cqlType string, protocolV primitive.ProtocolVersion) (interface{}, error) {
+	var dt datatype.DataType
+	switch cqlType {
+	case "int":
+		dt = datatype.Int
+	case "bigint":
+		dt = datatype.Bigint
+	case "float":
+		dt = datatype.Float
+	case "double":
+		dt = datatype.Double
+	case "boolean":
+		dt = datatype.Boolean
+	case "timestamp":
+		dt = datatype.Timestamp
+	case "blob":
+		dt = datatype.Blob
+	case "text":
+		dt = datatype.Varchar
+	default:
+		return nil, fmt.Errorf("unsupported CQL type: %s", cqlType)
+	}
+
+	bd, err := proxycore.DecodeType(dt, protocolV, value)
+	if err != nil {
+		return nil, fmt.Errorf("error encoding value: %w", err)
+	}
+
+	return bd, nil
+}
+
+// DecodeBytesToCassandraColumnType(): Function to decode incoming bytes parameter
+// for handleExecute scenario into corresponding go datatype
+//
+// Parameters:
+//   - b: []byte
+//   - choice:  datatype.DataType
+//   - protocolVersion: primitive.ProtocolVersion
+//
+// Returns: (interface{}, error)
+func DecodeBytesToCassandraColumnType(b []byte, choice datatype.PrimitiveType, protocolVersion primitive.ProtocolVersion) (interface{}, error) {
+	switch choice.GetDataTypeCode() {
+	case primitive.DataTypeCodeVarchar:
+		return proxycore.DecodeType(datatype.Varchar, protocolVersion, b)
+	case primitive.DataTypeCodeDouble:
+		return proxycore.DecodeType(datatype.Double, protocolVersion, b)
+	case primitive.DataTypeCodeFloat:
+		bytes, err := proxycore.DecodeType(datatype.Float, protocolVersion, b)
+		// casting result to float64 as float32 not supported by cassandra
+		if err != nil {
+			return nil, err
+		}
+		if res, ok := bytes.(float32); ok {
+			float32Str := fmt.Sprintf("%f", res)
+			// Convert string to float64
+			f64, err := strconv.ParseFloat(float32Str, 64)
+			if err != nil {
+				return nil, fmt.Errorf("error converting string to float64: %s", err)
+			}
+			return float32(f64), err
+		} else {
+			return nil, fmt.Errorf("error while casting to float64")
+		}
+	case primitive.DataTypeCodeBigint:
+		return proxycore.DecodeType(datatype.Bigint, protocolVersion, b)
+	case primitive.DataTypeCodeTimestamp:
+		return proxycore.DecodeType(datatype.Timestamp, protocolVersion, b)
+	case primitive.DataTypeCodeInt:
+		bytes, err := proxycore.DecodeType(datatype.Int, protocolVersion, b)
+		// casting result to int64 as int32 not supported by cassandra
+		if err != nil {
+			return nil, err
+		}
+		if res, ok := bytes.(int32); ok {
+			return int64(res), err
+		} else {
+			return nil, fmt.Errorf("error while casting to int64")
+		}
+	case primitive.DataTypeCodeBoolean:
+		return proxycore.DecodeType(datatype.Boolean, protocolVersion, b)
+	case primitive.DataTypeCodeUuid:
+		decodedUuid, err := proxycore.DecodeType(datatype.Uuid, protocolVersion, b)
+		if err != nil {
+			return nil, err
+		}
+		if primitiveUuid, ok := decodedUuid.(primitive.UUID); ok {
+			fmt.Printf("primitiveUuid.String() --- > %s", primitiveUuid.String())
+			return primitiveUuid.String(), err
+		}
+		return nil, fmt.Errorf("unable to decode uuid")
+	case primitive.DataTypeCodeDate:
+		return proxycore.DecodeType(datatype.Date, protocolVersion, b)
+	case primitive.DataTypeCodeBlob:
+		return proxycore.DecodeType(datatype.Blob, protocolVersion, b)
+	default:
+		res, err := decodeNonPrimitive(choice, b)
+		return res, err
+	}
+}
+
+// decodeNonPrimitive() Decodes non-primitive types like list, list, and list from byte data based on the provided datatype choice. Returns the decoded collection or an error if unsupported.
+func decodeNonPrimitive(choice datatype.PrimitiveType, b []byte) (interface{}, error) {
+	var err error
+	switch choice.String() {
+	case "list<bigint>":
+		decodedList, err := collectiondecoder.DecodeCollection(datatype.NewListType(datatype.Bigint), primitive.ProtocolVersion4, b)
+		if err != nil {
+			fmt.Println("Error decoding list:", err)
+			return nil, err
+		}
+		return decodedList, err
+	case "list<varchar>":
+		decodedList, err := collectiondecoder.DecodeCollection(datatype.NewListType(datatype.Varchar), primitive.ProtocolVersion4, b)
+		if err != nil {
+			fmt.Println("Error decoding list:", err)
+			return nil, err
+		}
+		return decodedList, err
+	case "list<double>":
+		decodedList, err := collectiondecoder.DecodeCollection(datatype.NewListType(datatype.Double), primitive.ProtocolVersion4, b)
+		if err != nil {
+			fmt.Println("Error decoding list:", err)
+			return nil, err
+		}
+		return decodedList, err
+	default:
+		err = fmt.Errorf("unsupported Datatype to decode - %s", choice)
+		return nil, err
+	}
+}
+
+// SetupLogger() initializes a zap.Logger instance based on the provided log level and logger configuration.
+// If loggerConfig specifies file output, it sets up a file-based logger. Otherwise, it defaults to console output.
+// Returns the configured zap.Logger or an error if setup fails.
+func SetupLogger(logLevel string, loggerConfig *LoggerConfig) (*zap.Logger, error) {
+	level := getLogLevel(logLevel)
+
+	if loggerConfig != nil && loggerConfig.OutputType == "file" {
+		return setupFileLogger(level, loggerConfig)
+	}
+
+	return setupConsoleLogger(level)
+}
+
+// getLogLevel() translates a string log level to a zap.AtomicLevel.
+// Supports "info", "debug", "error", and "warn" levels, defaulting to "info" if an unrecognized level is provided.
+func getLogLevel(logLevel string) zap.AtomicLevel {
+	level := zap.NewAtomicLevel()
+
+	switch logLevel {
+	case "info":
+		level.SetLevel(zap.InfoLevel)
+	case "debug":
+		level.SetLevel(zap.DebugLevel)
+	case "error":
+		level.SetLevel(zap.ErrorLevel)
+	case "warn":
+		level.SetLevel(zap.WarnLevel)
+	default:
+		level.SetLevel(zap.InfoLevel)
+	}
+
+	return level
+}
+
+// setupFileLogger() configures a zap.Logger for file output using a lumberjack.Logger for log rotation.
+// Accepts a zap.AtomicLevel and a LoggerConfig struct to customize log output and rotation settings.
+// Returns the configured zap.Logger or an error if setup fails.
+func setupFileLogger(level zap.AtomicLevel, loggerConfig *LoggerConfig) (*zap.Logger, error) {
+	rotationalLogger := &lumberjack.Logger{
+		Filename:   defaultIfEmpty(loggerConfig.Filename, "/var/log/cassandra-to-spanner-proxy/output.log"),
+		MaxSize:    loggerConfig.MaxSize,                       // megabytes, default 100MB
+		MaxAge:     defaultIfZero(loggerConfig.MaxAge, 3),      // setting default value to 3 days
+		MaxBackups: defaultIfZero(loggerConfig.MaxBackups, 10), // setting default max backups to 10 files
+		Compress:   loggerConfig.Compress,
+	}
+
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.AddSync(rotationalLogger),
+		level,
+	)
+
+	return zap.New(core), nil
+}
+
+// setupConsoleLogger() configures a zap.Logger for console output.
+// Accepts a zap.AtomicLevel to set the logging level.
+// Returns the configured zap.Logger or an error if setup fails.
+func setupConsoleLogger(level zap.AtomicLevel) (*zap.Logger, error) {
+	config := zap.Config{
+		Encoding:         "json", // or "console"
+		Level:            level,  // default log level
+		OutputPaths:      []string{"stdout"},
+		ErrorOutputPaths: []string{"stderr"},
+		EncoderConfig: zapcore.EncoderConfig{
+			TimeKey:        "time",
+			CallerKey:      "caller",
+			LevelKey:       "level",
+			NameKey:        "logger",
+			MessageKey:     "msg",
+			StacktraceKey:  "stacktrace",
+			LineEnding:     zapcore.DefaultLineEnding,
+			EncodeLevel:    zapcore.LowercaseLevelEncoder, // or zapcore.LowercaseColorLevelEncoder for console
+			EncodeTime:     zapcore.ISO8601TimeEncoder,
+			EncodeDuration: zapcore.StringDurationEncoder,
+			EncodeCaller:   zapcore.ShortCallerEncoder,
+		},
+	}
+
+	return config.Build()
+}
+
+// defaultIfEmpty() returns a default string value if the provided value is empty.
+// Useful for setting default configuration values.
+func defaultIfEmpty(value, defaultValue string) string {
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}
+
+// defaultIfZero() returns a default integer value if the provided value is zero.
+// Useful for setting default configuration values.
+func defaultIfZero(value, defaultValue int) int {
+	if value == 0 {
+		return defaultValue
+	}
+	return value
+}
+
+// TypeConversion() converts a Go data type to a Cassandra protocol-compliant byte array.
+//
+// Parameters:
+//   - s: The data to be converted.
+//   - protocalV: Cassandra protocol version.
+//
+// Returns: Byte array in Cassandra protocol format or an error if conversion fails.
+func TypeConversion(s interface{}, protocalV primitive.ProtocolVersion) ([]byte, error) {
+	var bytes []byte
+	var err error
+	switch v := s.(type) {
+	case string:
+		bytes, err = proxycore.EncodeType(datatype.Varchar, protocalV, v)
+	case time.Time:
+		bytes, err = proxycore.EncodeType(datatype.Timestamp, protocalV, v)
+	case []byte:
+		bytes, err = proxycore.EncodeType(datatype.Blob, protocalV, v)
+	case int64:
+		bytes, err = proxycore.EncodeType(datatype.Bigint, protocalV, v)
+	case int:
+		bytes, err = proxycore.EncodeType(datatype.Int, protocalV, v)
+	case bool:
+		bytes, err = proxycore.EncodeType(datatype.Boolean, protocalV, v)
+	case map[string]string:
+		bytes, err = proxycore.EncodeType(MapOfStrToStr, protocalV, v)
+	case float64:
+		bytes, err = proxycore.EncodeType(datatype.Double, protocalV, v)
+	case float32:
+		bytes, err = proxycore.EncodeType(datatype.Float, protocalV, v)
+	case []string:
+		bytes, err = proxycore.EncodeType(SetOfStr, protocalV, v)
+
+	default:
+		err = fmt.Errorf("%v - %v", "Unknown Datatype Identified", s)
+	}
+
+	return bytes, err
+}

--- a/cassandra-bigtable-proxy/utilities/utils.go
+++ b/cassandra-bigtable-proxy/utilities/utils.go
@@ -1,17 +1,17 @@
 /*
- * Copyright (C) 2025 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+* Copyright (C) 2025 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not
+* use this file except in compliance with the License. You may obtain a copy of
+* the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations under
+* the License.
  */
 package utilities
 
@@ -29,10 +29,6 @@ import (
 	"github.com/ollionorg/cassandra-to-bigtable-proxy/proxycore"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-)
-
-const (
-	CustomWritetime = "writetime_"
 )
 
 type LoggerConfig struct {
@@ -78,6 +74,74 @@ var (
 var (
 	EncodedTrue, _  = proxycore.EncodeType(datatype.Boolean, primitive.ProtocolVersion4, true)
 	EncodedFalse, _ = proxycore.EncodeType(datatype.Boolean, primitive.ProtocolVersion4, false)
+)
+
+const (
+	// Primitive types
+	CassandraTypeText      = "text"
+	CassandraTypeString    = "string"
+	CassandraTypeBlob      = "blob"
+	CassandraTypeTimestamp = "timestamp"
+	CassandraTypeInt       = "int"
+	CassandraTypeBigint    = "bigint"
+	CassandraTypeBoolean   = "boolean"
+	CassandraTypeUuid      = "uuid"
+	CassandraTypeFloat     = "float"
+	CassandraTypeDouble    = "double"
+
+	// Map types
+	CassandraTypeMapTextBoolean        = "map<text,boolean>"
+	CassandraTypeMapTextInt            = "map<text,int>"
+	CassandraTypeMapTextBigint         = "map<text,bigint>"
+	CassandraTypeMapTextFloat          = "map<text,float>"
+	CassandraTypeMapTextDouble         = "map<text,double>"
+	CassandraTypeMapTextText           = "map<text,text>"
+	CassandraTypeMapTextTimestamp      = "map<text,timestamp>"
+	CassandraTypeMapTimestampText      = "map<timestamp,text>"
+	CassandraTypeMapTimestampBoolean   = "map<timestamp,boolean>"
+	CassandraTypeMapTimestampFloat     = "map<timestamp,float>"
+	CassandraTypeMapTimestampDouble    = "map<timestamp,double>"
+	CassandraTypeMapTimestampBigint    = "map<timestamp,bigint>"
+	CassandraTypeMapTimestampInt       = "map<timestamp,int>"
+	CassandraTypeMapTimestampTimestamp = "map<timestamp,timestamp>"
+
+	// List types
+	CassandraTypeListText            = "list<text>"
+	CassandraTypeListTextFrozen      = "frozen<list<text>>"
+	CassandraTypeListInt             = "list<int>"
+	CassandraTypeListIntFrozen       = "frozen<list<int>>"
+	CassandraTypeListBigint          = "list<bigint>"
+	CassandraTypeListBigintFrozen    = "frozen<list<bigint>>"
+	CassandraTypeListFloat           = "list<float>"
+	CassandraTypeListFloatFrozen     = "frozen<list<float>>"
+	CassandraTypeListDouble          = "list<double>"
+	CassandraTypeListDoubleFrozen    = "frozen<list<double>>"
+	CassandraTypeListTimestamp       = "list<timestamp>"
+	CassandraTypeListTimestampFrozen = "frozen<list<timestamp>>"
+	CassandraTypeListBoolean         = "list<boolean>"
+	CassandraTypeListBooleanFrozen   = "frozen<list<boolean>>"
+
+	// Set types
+	CassandraTypeSetInt             = "set<int>"
+	CassandraTypeSetIntFrozen       = "frozen<set<int>>"
+	CassandraTypeSetBigint          = "set<bigint>"
+	CassandraTypeSetBigintFrozen    = "frozen<set<bigint>>"
+	CassandraTypeSetFloat           = "set<float>"
+	CassandraTypeSetFloatFrozen     = "frozen<set<float>>"
+	CassandraTypeSetDouble          = "set<double>"
+	CassandraTypeSetDoubleFrozen    = "frozen<set<double>>"
+	CassandraTypeSetTimestamp       = "set<timestamp>"
+	CassandraTypeSetTimestampFrozen = "frozen<set<timestamp>>"
+	CassandraTypeSetText            = "set<text>"
+	CassandraTypeSetTextFrozen      = "frozen<set<text>>"
+	CassandraTypeSetBoolean         = "set<boolean>"
+	CassandraTypeSetBooleanFrozen   = "frozen<set<boolean>>"
+)
+const (
+	Info  = "info"
+	Debug = "debug"
+	Error = "error"
+	Warn  = "warn"
 )
 
 // formatTimestamp formats the Timestamp into time.
@@ -138,116 +202,83 @@ func KeyExistsInList(key string, list []string) bool {
 func GetCassandraColumnType(c string) (datatype.DataType, error) {
 	choice := strings.ToLower(strings.ReplaceAll(c, " ", ""))
 	switch choice {
-	case "text":
+	case CassandraTypeText:
 		return datatype.Varchar, nil
-	case "blob":
+	case CassandraTypeBlob:
 		return datatype.Blob, nil
-	case "timestamp":
+	case CassandraTypeTimestamp:
 		return datatype.Timestamp, nil
-	case "int":
+	case CassandraTypeInt:
 		return datatype.Int, nil
-	case "bigint":
+	case CassandraTypeBigint:
 		return datatype.Bigint, nil
-	case "boolean":
+	case CassandraTypeBoolean:
 		return datatype.Boolean, nil
-	case "uuid":
+	case CassandraTypeUuid:
 		return datatype.Uuid, nil
-	case "float":
+	case CassandraTypeFloat:
 		return datatype.Float, nil
-	case "double":
+	case CassandraTypeDouble:
 		return datatype.Double, nil
-	case "map<text,boolean>":
+	case CassandraTypeMapTextBoolean:
 		return MapOfStrToBool, nil
-	case "map<text,int>":
+	case CassandraTypeMapTextInt:
 		return MapOfStrToInt, nil
-	case "map<text,bigint>":
+	case CassandraTypeMapTextBigint:
 		return MapOfStrToBigInt, nil
-	case "map<text,float>":
+	case CassandraTypeMapTextFloat:
 		return MapOfStrToFloat, nil
-	case "map<text,double>":
+	case CassandraTypeMapTextDouble:
 		return MapOfStrToDouble, nil
-	case "map<text,text>":
+	case CassandraTypeMapTextText:
 		return MapOfStrToStr, nil
-	case "map<text,timestamp>":
+	case CassandraTypeMapTextTimestamp:
 		return MapOfStrToTime, nil
-	case "map<timestamp,text>":
+	case CassandraTypeMapTimestampText:
 		return MapOfTimeToStr, nil
-	case "map<timestamp,boolean>":
+	case CassandraTypeMapTimestampBoolean:
 		return MapOfTimeToBool, nil
-	case "map<timestamp,float>":
+	case CassandraTypeMapTimestampFloat:
 		return MapOfTimeToFloat, nil
-	case "map<timestamp,double>":
+	case CassandraTypeMapTimestampDouble:
 		return MapOfTimeToDouble, nil
-	case "map<timestamp,bigint>":
+	case CassandraTypeMapTimestampBigint:
 		return MapOfTimeToBigInt, nil
-	case "map<timestamp,int>":
+	case CassandraTypeMapTimestampInt:
 		return MapOfTimeToInt, nil
-	case "map<timestamp,timestamp>":
+	case CassandraTypeMapTimestampTimestamp:
 		return MapOfTimeToTime, nil
-	case "list<text>", "frozen<list<text>>":
-		return datatype.NewListType(datatype.Varchar), nil
-	case "set<int>", "frozen<set<int>>":
+	case CassandraTypeListText, CassandraTypeListTextFrozen:
+		return ListOfStr, nil
+	case CassandraTypeSetInt, CassandraTypeSetIntFrozen:
 		return SetOfInt, nil
-	case "set<bigint>", "frozen<set<bigint>>":
+	case CassandraTypeSetBigint, CassandraTypeSetBigintFrozen:
 		return SetOfBigInt, nil
-	case "set<float>", "frozen<set<float>>":
+	case CassandraTypeSetFloat, CassandraTypeSetFloatFrozen:
 		return SetOfFloat, nil
-	case "set<double>", "frozen<set<double>>":
+	case CassandraTypeSetDouble, CassandraTypeSetDoubleFrozen:
 		return SetOfDouble, nil
-	case "set<timestamp>", "frozen<set<timestamp>>":
+	case CassandraTypeSetTimestamp, CassandraTypeSetTimestampFrozen:
 		return SetOfTimeStamp, nil
-	case "set<text>", "frozen<set<text>>":
+	case CassandraTypeSetText, CassandraTypeSetTextFrozen:
 		return SetOfStr, nil
-	case "set<boolean>", "frozen<set<boolean>>":
+	case CassandraTypeSetBoolean, CassandraTypeSetBooleanFrozen:
 		return SetOfBool, nil
-	case "list<boolean>", "frozen<list<boolean>>":
+	case CassandraTypeListBoolean, CassandraTypeListBooleanFrozen:
 		return ListOfBool, nil
-	case "list<int>", "frozen<list<int>>":
+	case CassandraTypeListInt, CassandraTypeListIntFrozen:
 		return ListOfInt, nil
-	case "list<bigint>", "frozen<list<bigint>>":
+	case CassandraTypeListBigint, CassandraTypeListBigintFrozen:
 		return ListOfBigInt, nil
-	case "list<float>", "frozen<list<float>>":
+	case CassandraTypeListFloat, CassandraTypeListFloatFrozen:
 		return ListOfFloat, nil
-	case "list<double>", "frozen<list<double>>":
+	case CassandraTypeListDouble, CassandraTypeListDoubleFrozen:
 		return ListOfDouble, nil
-	case "list<timestamp>", "frozen<list<timestamp>>":
+	case CassandraTypeListTimestamp, CassandraTypeListTimestampFrozen:
 		return ListOfTimeStamp, nil
-
 	default:
-		return nil, fmt.Errorf("%s", "Error in returning column type")
+		return nil, fmt.Errorf("unsupported column type: %s", choice)
 	}
-}
-
-// DecodeEncodedValues() Function used to decode the encoded values into its original format
-func DecodeEncodedValues(value []byte, cqlType string, protocolV primitive.ProtocolVersion) (interface{}, error) {
-	var dt datatype.DataType
-	switch cqlType {
-	case "int":
-		dt = datatype.Int
-	case "bigint":
-		dt = datatype.Bigint
-	case "float":
-		dt = datatype.Float
-	case "double":
-		dt = datatype.Double
-	case "boolean":
-		dt = datatype.Boolean
-	case "timestamp":
-		dt = datatype.Timestamp
-	case "blob":
-		dt = datatype.Blob
-	case "text":
-		dt = datatype.Varchar
-	default:
-		return nil, fmt.Errorf("unsupported CQL type: %s", cqlType)
-	}
-
-	bd, err := proxycore.DecodeType(dt, protocolV, value)
-	if err != nil {
-		return nil, fmt.Errorf("error encoding value: %w", err)
-	}
-
-	return bd, nil
 }
 
 // DecodeBytesToCassandraColumnType(): Function to decode incoming bytes parameter
@@ -259,29 +290,14 @@ func DecodeEncodedValues(value []byte, cqlType string, protocolV primitive.Proto
 //   - protocolVersion: primitive.ProtocolVersion
 //
 // Returns: (interface{}, error)
-func DecodeBytesToCassandraColumnType(b []byte, choice datatype.PrimitiveType, protocolVersion primitive.ProtocolVersion) (interface{}, error) {
+func DecodeBytesToCassandraColumnType(b []byte, choice datatype.PrimitiveType, protocolVersion primitive.ProtocolVersion) (any, error) {
 	switch choice.GetDataTypeCode() {
 	case primitive.DataTypeCodeVarchar:
 		return proxycore.DecodeType(datatype.Varchar, protocolVersion, b)
 	case primitive.DataTypeCodeDouble:
 		return proxycore.DecodeType(datatype.Double, protocolVersion, b)
 	case primitive.DataTypeCodeFloat:
-		bytes, err := proxycore.DecodeType(datatype.Float, protocolVersion, b)
-		// casting result to float64 as float32 not supported by cassandra
-		if err != nil {
-			return nil, err
-		}
-		if res, ok := bytes.(float32); ok {
-			float32Str := fmt.Sprintf("%f", res)
-			// Convert string to float64
-			f64, err := strconv.ParseFloat(float32Str, 64)
-			if err != nil {
-				return nil, fmt.Errorf("error converting string to float64: %s", err)
-			}
-			return float32(f64), err
-		} else {
-			return nil, fmt.Errorf("error while casting to float64")
-		}
+		return proxycore.DecodeType(datatype.Float, protocolVersion, b)
 	case primitive.DataTypeCodeBigint:
 		return proxycore.DecodeType(datatype.Bigint, protocolVersion, b)
 	case primitive.DataTypeCodeTimestamp:
@@ -299,16 +315,6 @@ func DecodeBytesToCassandraColumnType(b []byte, choice datatype.PrimitiveType, p
 		}
 	case primitive.DataTypeCodeBoolean:
 		return proxycore.DecodeType(datatype.Boolean, protocolVersion, b)
-	case primitive.DataTypeCodeUuid:
-		decodedUuid, err := proxycore.DecodeType(datatype.Uuid, protocolVersion, b)
-		if err != nil {
-			return nil, err
-		}
-		if primitiveUuid, ok := decodedUuid.(primitive.UUID); ok {
-			fmt.Printf("primitiveUuid.String() --- > %s", primitiveUuid.String())
-			return primitiveUuid.String(), err
-		}
-		return nil, fmt.Errorf("unable to decode uuid")
 	case primitive.DataTypeCodeDate:
 		return proxycore.DecodeType(datatype.Date, protocolVersion, b)
 	case primitive.DataTypeCodeBlob:
@@ -320,34 +326,42 @@ func DecodeBytesToCassandraColumnType(b []byte, choice datatype.PrimitiveType, p
 }
 
 // decodeNonPrimitive() Decodes non-primitive types like list, list, and list from byte data based on the provided datatype choice. Returns the decoded collection or an error if unsupported.
-func decodeNonPrimitive(choice datatype.PrimitiveType, b []byte) (interface{}, error) {
+func decodeNonPrimitive(choice datatype.PrimitiveType, b []byte) (any, error) {
 	var err error
-	switch choice.String() {
-	case "list<bigint>":
-		decodedList, err := collectiondecoder.DecodeCollection(datatype.NewListType(datatype.Bigint), primitive.ProtocolVersion4, b)
-		if err != nil {
-			fmt.Println("Error decoding list:", err)
+	// Check if it's a list type
+	if choice.GetDataTypeCode() == primitive.DataTypeCodeList {
+		// Get the element type
+		listType := choice.(datatype.ListType)
+		elementType := listType.GetElementType()
+
+		// Now check the element type's code
+		switch elementType.GetDataTypeCode() {
+		case primitive.DataTypeCodeVarchar:
+			decodedList, err := collectiondecoder.DecodeCollection(ListOfStr, primitive.ProtocolVersion4, b)
+			if err != nil {
+				return nil, err
+			}
+			return decodedList, err
+		case primitive.DataTypeCodeBigint:
+			decodedList, err := collectiondecoder.DecodeCollection(ListOfBigInt, primitive.ProtocolVersion4, b)
+			if err != nil {
+				return nil, err
+			}
+			return decodedList, err
+		case primitive.DataTypeCodeDouble:
+			decodedList, err := collectiondecoder.DecodeCollection(ListOfDouble, primitive.ProtocolVersion4, b)
+			if err != nil {
+				return nil, err
+			}
+			return decodedList, err
+		default:
+			err = fmt.Errorf("unsupported list element type to decode - %v", elementType.GetDataTypeCode())
 			return nil, err
 		}
-		return decodedList, err
-	case "list<varchar>":
-		decodedList, err := collectiondecoder.DecodeCollection(datatype.NewListType(datatype.Varchar), primitive.ProtocolVersion4, b)
-		if err != nil {
-			fmt.Println("Error decoding list:", err)
-			return nil, err
-		}
-		return decodedList, err
-	case "list<double>":
-		decodedList, err := collectiondecoder.DecodeCollection(datatype.NewListType(datatype.Double), primitive.ProtocolVersion4, b)
-		if err != nil {
-			fmt.Println("Error decoding list:", err)
-			return nil, err
-		}
-		return decodedList, err
-	default:
-		err = fmt.Errorf("unsupported Datatype to decode - %s", choice)
-		return nil, err
 	}
+
+	err = fmt.Errorf("unsupported Datatype to decode - %v", choice.GetDataTypeCode())
+	return nil, err
 }
 
 // SetupLogger() initializes a zap.Logger instance based on the provided log level and logger configuration.
@@ -369,13 +383,13 @@ func getLogLevel(logLevel string) zap.AtomicLevel {
 	level := zap.NewAtomicLevel()
 
 	switch logLevel {
-	case "info":
+	case Info:
 		level.SetLevel(zap.InfoLevel)
-	case "debug":
+	case Debug:
 		level.SetLevel(zap.DebugLevel)
-	case "error":
+	case Error:
 		level.SetLevel(zap.ErrorLevel)
-	case "warn":
+	case Warn:
 		level.SetLevel(zap.WarnLevel)
 	default:
 		level.SetLevel(zap.InfoLevel)
@@ -457,7 +471,7 @@ func defaultIfZero(value, defaultValue int) int {
 //   - protocalV: Cassandra protocol version.
 //
 // Returns: Byte array in Cassandra protocol format or an error if conversion fails.
-func TypeConversion(s interface{}, protocalV primitive.ProtocolVersion) ([]byte, error) {
+func TypeConversion(s any, protocalV primitive.ProtocolVersion) ([]byte, error) {
 	var bytes []byte
 	var err error
 	switch v := s.(type) {
@@ -487,4 +501,102 @@ func TypeConversion(s interface{}, protocalV primitive.ProtocolVersion) ([]byte,
 	}
 
 	return bytes, err
+}
+
+func DataConversionInInsertionIfRequired(value any, pv primitive.ProtocolVersion, cqlType string, responseType string) (any, error) {
+	switch cqlType {
+	case CassandraTypeBoolean:
+		switch responseType {
+		case CassandraTypeString:
+			val, err := strconv.ParseBool(value.(string))
+			if err != nil {
+				return nil, err
+			}
+			if val {
+				return "1", nil
+			} else {
+				return "0", nil
+			}
+		default:
+			return EncodeBool(value, pv)
+		}
+	case CassandraTypeInt:
+		switch responseType {
+		case CassandraTypeString:
+			val, err := strconv.ParseInt(value.(string), 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			stringVal := strconv.FormatInt(val, 10)
+			return stringVal, nil
+		default:
+			return EncodeInt(value, pv)
+		}
+	default:
+		return value, nil
+	}
+}
+
+func EncodeBool(value any, pv primitive.ProtocolVersion) ([]byte, error) {
+	switch v := value.(type) {
+	case string:
+		val, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, err
+		}
+		strVal := "0"
+		if val {
+			strVal = "1"
+		}
+		intVal, _ := strconv.ParseInt(strVal, 10, 64)
+		bd, err := proxycore.EncodeType(datatype.Bigint, pv, intVal)
+		return bd, err
+	case bool:
+		var valInBigint int64
+		if v {
+			valInBigint = 1
+		} else {
+			valInBigint = 0
+		}
+		bd, err := proxycore.EncodeType(datatype.Bigint, pv, valInBigint)
+		return bd, err
+	case []byte:
+		vaInInterface, err := proxycore.DecodeType(datatype.Boolean, pv, v)
+		if err != nil {
+			return nil, err
+		}
+		if vaInInterface.(bool) {
+			return proxycore.EncodeType(datatype.Bigint, pv, 1)
+		} else {
+			return proxycore.EncodeType(datatype.Bigint, pv, 0)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported type: %v", value)
+	}
+}
+
+func EncodeInt(value any, pv primitive.ProtocolVersion) ([]byte, error) {
+	switch v := value.(type) {
+	case string:
+		val, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		bd, err := proxycore.EncodeType(datatype.Bigint, pv, val)
+		return bd, err
+	case int32:
+		bd, err := proxycore.EncodeType(datatype.Bigint, pv, int32(v))
+		if err != nil {
+			return nil, err
+		}
+		return bd, err
+	case []byte:
+		intVal, err := proxycore.DecodeType(datatype.Int, pv, v)
+		if err != nil {
+			return nil, err
+		}
+		return proxycore.EncodeType(datatype.Bigint, pv, intVal.(int32))
+	default:
+		return nil, fmt.Errorf("unsupported type: %v", value)
+	}
 }

--- a/cassandra-bigtable-proxy/utilities/utils_test.go
+++ b/cassandra-bigtable-proxy/utilities/utils_test.go
@@ -16,7 +16,6 @@
 package utilities
 
 import (
-	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -26,128 +25,6 @@ import (
 	"github.com/ollionorg/cassandra-to-bigtable-proxy/proxycore"
 	"github.com/stretchr/testify/assert"
 )
-
-// TestKeyExistsInList tests the keyExistsInList function with various inputs.
-func TestKeyExistsInList(t *testing.T) {
-	cases := []struct {
-		name     string
-		key      string
-		list     []string
-		expected bool
-	}{
-		{
-			name:     "Key present in list",
-			key:      "banana",
-			list:     []string{"apple", "banana", "cherry"},
-			expected: true,
-		},
-		{
-			name:     "Key not present in list",
-			key:      "mango",
-			list:     []string{"apple", "banana", "cherry"},
-			expected: false,
-		},
-		{
-			name:     "Empty list",
-			key:      "banana",
-			list:     []string{},
-			expected: false,
-		},
-		{
-			name:     "Nil list",
-			key:      "banana",
-			list:     nil,
-			expected: false,
-		},
-		{
-			name:     "Key at the beginning",
-			key:      "apple",
-			list:     []string{"apple", "banana", "cherry"},
-			expected: true,
-		},
-		{
-			name:     "Key at the end",
-			key:      "cherry",
-			list:     []string{"apple", "banana", "cherry"},
-			expected: true,
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := KeyExistsInList(tc.key, tc.list)
-			if got != tc.expected {
-				t.Errorf("%s: expected %v, got %v", tc.name, tc.expected, got)
-			}
-		})
-	}
-}
-
-func TestFormatTimestamp(t *testing.T) {
-	tests := []struct {
-		name          string
-		input         int64
-		expectedTime  time.Time
-		expectedError error
-	}{
-		{
-			name:          "Timestamp less than a second",
-			input:         500, // Some value less than a second
-			expectedTime:  time.Unix(500, 0),
-			expectedError: nil,
-		},
-		{
-			name:          "Timestamp in seconds",
-			input:         1620655315, // Some value in seconds
-			expectedTime:  time.Unix(1620655315, 0),
-			expectedError: nil,
-		},
-		{
-			name:          "Timestamp in milliseconds",
-			input:         1620655315000, // Some value in milliseconds
-			expectedTime:  time.Unix(1620655315, 0),
-			expectedError: nil,
-		},
-		{
-			name:          "Timestamp in microseconds",
-			input:         1620655315000000, // Some value in microseconds
-			expectedTime:  time.Unix(1620655315, 0),
-			expectedError: nil,
-		},
-		{
-			name:          "Timestamp in nanoseconds",
-			input:         162065531000000000, // Some value in nanoseconds
-			expectedTime:  time.Unix(162065531, 0),
-			expectedError: nil,
-		},
-		{
-			name:          "Zero timestamp",
-			input:         0, // Invalid timestamp
-			expectedTime:  time.Time{},
-			expectedError: errors.New("no valid timestamp found"),
-		},
-		{
-			name:          "Invalid timestamp",
-			input:         2893187128318378367, // Invalid timestamp
-			expectedTime:  time.Time{},
-			expectedError: errors.New("no valid timestamp found"),
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			result, err := FormatTimestamp(test.input)
-
-			if result != nil && !result.Equal(test.expectedTime) {
-				t.Errorf("Expected time: %v, got: %v", test.expectedTime, result)
-			}
-
-			if !errorEquals(err, test.expectedError) {
-				t.Errorf("Expected error: %v, got: %v", test.expectedError, err)
-			}
-		})
-	}
-}
 
 func TestGetCassandraColumnType(t *testing.T) {
 	testCases := []struct {
@@ -402,13 +279,6 @@ func TestDecodeNonPrimitive(t *testing.T) {
 			dataType:    ListOfDouble,
 			expected:    []float64{123.45, 456.78},
 			expectError: false,
-		},
-		{
-			name:         "Invalid list data",
-			input:        []byte("invalid list"),
-			dataType:     ListOfStr,
-			expectError:  true,
-			errorMessage: "EOF",
 		},
 		{
 			name:         "Unsupported list element type",

--- a/cassandra-bigtable-proxy/utilities/utils_test.go
+++ b/cassandra-bigtable-proxy/utilities/utils_test.go
@@ -1,0 +1,729 @@
+/*
+ * Copyright (C) 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package utilities
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/datastax/go-cassandra-native-protocol/datatype"
+	"github.com/datastax/go-cassandra-native-protocol/primitive"
+)
+
+// TestKeyExistsInList tests the keyExistsInList function with various inputs.
+func TestKeyExistsInList(t *testing.T) {
+	cases := []struct {
+		name     string
+		key      string
+		list     []string
+		expected bool
+	}{
+		{
+			name:     "Key present in list",
+			key:      "banana",
+			list:     []string{"apple", "banana", "cherry"},
+			expected: true,
+		},
+		{
+			name:     "Key not present in list",
+			key:      "mango",
+			list:     []string{"apple", "banana", "cherry"},
+			expected: false,
+		},
+		{
+			name:     "Empty list",
+			key:      "banana",
+			list:     []string{},
+			expected: false,
+		},
+		{
+			name:     "Nil list",
+			key:      "banana",
+			list:     nil,
+			expected: false,
+		},
+		{
+			name:     "Key at the beginning",
+			key:      "apple",
+			list:     []string{"apple", "banana", "cherry"},
+			expected: true,
+		},
+		{
+			name:     "Key at the end",
+			key:      "cherry",
+			list:     []string{"apple", "banana", "cherry"},
+			expected: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := KeyExistsInList(tc.key, tc.list)
+			if got != tc.expected {
+				t.Errorf("%s: expected %v, got %v", tc.name, tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestFormatTimestamp(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         int64
+		expectedTime  time.Time
+		expectedError error
+	}{
+		{
+			name:          "Timestamp less than a second",
+			input:         500, // Some value less than a second
+			expectedTime:  time.Unix(500, 0),
+			expectedError: nil,
+		},
+		{
+			name:          "Timestamp in seconds",
+			input:         1620655315, // Some value in seconds
+			expectedTime:  time.Unix(1620655315, 0),
+			expectedError: nil,
+		},
+		{
+			name:          "Timestamp in milliseconds",
+			input:         1620655315000, // Some value in milliseconds
+			expectedTime:  time.Unix(1620655315, 0),
+			expectedError: nil,
+		},
+		{
+			name:          "Timestamp in microseconds",
+			input:         1620655315000000, // Some value in microseconds
+			expectedTime:  time.Unix(1620655315, 0),
+			expectedError: nil,
+		},
+		{
+			name:          "Timestamp in nanoseconds",
+			input:         162065531000000000, // Some value in nanoseconds
+			expectedTime:  time.Unix(162065531, 0),
+			expectedError: nil,
+		},
+		{
+			name:          "Zero timestamp",
+			input:         0, // Invalid timestamp
+			expectedTime:  time.Time{},
+			expectedError: errors.New("no valid timestamp found"),
+		},
+		{
+			name:          "Invalid timestamp",
+			input:         2893187128318378367, // Invalid timestamp
+			expectedTime:  time.Time{},
+			expectedError: errors.New("no valid timestamp found"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := FormatTimestamp(test.input)
+
+			if result != nil && !result.Equal(test.expectedTime) {
+				t.Errorf("Expected time: %v, got: %v", test.expectedTime, result)
+			}
+
+			if !errorEquals(err, test.expectedError) {
+				t.Errorf("Expected error: %v, got: %v", test.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestGetCassandraColumnType(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		wantType datatype.DataType
+		wantErr  bool
+	}{
+		{"Text Type", "text", datatype.Varchar, false},
+		{"Bolob Type", "blob", datatype.Blob, false},
+		{"Timestamp Type", "timestamp", datatype.Timestamp, false},
+		{"Int Type", "int", datatype.Int, false},
+		{"Float Type", "float", datatype.Float, false},
+		{"Double Type", "double", datatype.Double, false},
+		{"Bigint Type", "bigint", datatype.Bigint, false},
+		{"Boolean Type", "boolean", datatype.Boolean, false},
+		{"Uuid Type", "uuid", datatype.Uuid, false},
+		{"map<text, boolean> Type", "map<text, boolean>", datatype.NewMapType(datatype.Varchar, datatype.Boolean), false},
+		{"map<text, text> Type", "map<text, text>", datatype.NewMapType(datatype.Varchar, datatype.Varchar), false},
+		{"list<text> Type", "list<text>", datatype.NewListType(datatype.Varchar), false},
+		{"frozen<list<text>> Type", "frozen<list<text>>", datatype.NewListType(datatype.Varchar), false},
+		{"set<text> Type", "set<text>", datatype.NewSetType(datatype.Varchar), false},
+		{"frozen<set<text>> Type", "frozen<set<text>>", datatype.NewSetType(datatype.Varchar), false},
+		{"Invalid Type", "unknown", nil, true},
+		// Future scope items below:
+		{"map<text, int> Type", "map<text, int>", datatype.NewMapType(datatype.Varchar, datatype.Int), false},
+		{"map<text, bigint> Type", "map<text, bigint>", datatype.NewMapType(datatype.Varchar, datatype.Bigint), false},
+		{"map<text, float> Type", "map<text, float>", datatype.NewMapType(datatype.Varchar, datatype.Float), false},
+		{"map<text, double> Type", "map<text, double>", datatype.NewMapType(datatype.Varchar, datatype.Double), false},
+		{"map<text, timestamp> Type", "map<text, timestamp>", datatype.NewMapType(datatype.Varchar, datatype.Timestamp), false},
+		{"map<timestamp, text> Type", "map<timestamp, text>", datatype.NewMapType(datatype.Timestamp, datatype.Varchar), false},
+		{"map<timestamp, boolean> Type", "map<timestamp, boolean>", datatype.NewMapType(datatype.Timestamp, datatype.Boolean), false},
+		{"map<timestamp, int> Type", "map<timestamp, int>", datatype.NewMapType(datatype.Timestamp, datatype.Int), false},
+		{"map<timestamp, bigint> Type", "map<timestamp, bigint>", datatype.NewMapType(datatype.Timestamp, datatype.Bigint), false},
+		{"map<timestamp, float> Type", "map<timestamp, float>", datatype.NewMapType(datatype.Timestamp, datatype.Float), false},
+		{"map<timestamp, double> Type", "map<timestamp, double>", datatype.NewMapType(datatype.Timestamp, datatype.Double), false},
+		{"map<timestamp, timestamp> Type", "map<timestamp, timestamp>", datatype.NewMapType(datatype.Timestamp, datatype.Timestamp), false},
+		{"set<int> Type", "set<int>", datatype.NewSetType(datatype.Int), false},
+		{"set<bigint> Type", "set<bigint>", datatype.NewSetType(datatype.Bigint), false},
+		{"set<float> Type", "set<float>", datatype.NewSetType(datatype.Float), false},
+		{"set<double> Type", "set<double>", datatype.NewSetType(datatype.Double), false},
+		{"set<boolean> Type", "set<boolean>", datatype.NewSetType(datatype.Boolean), false},
+		{"set<timestamp> Type", "set<timestamp>", datatype.NewSetType(datatype.Timestamp), false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotType, err := GetCassandraColumnType(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("getCassandraColumnType(%s) error = %v, wantErr %v", tc.input, err, tc.wantErr)
+				return
+			}
+
+			if err == nil && !reflect.DeepEqual(gotType, tc.wantType) {
+				t.Errorf("getCassandraColumnType(%s) = %v, want %v", tc.input, gotType, tc.wantType)
+			}
+		})
+	}
+}
+
+func errorEquals(err1, err2 error) bool {
+	if (err1 == nil && err2 != nil) || (err1 != nil && err2 == nil) {
+		return false
+	}
+	if err1 != nil && err2 != nil && err1.Error() != err2.Error() {
+		return false
+	}
+	return true
+}
+
+func TestDecodeEncodedValues(t *testing.T) {
+	type args struct {
+		value     []byte
+		cqlType   string
+		protocolV primitive.ProtocolVersion
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name: "Decode int value",
+			args: args{
+				value:     []byte{0, 0, 0, 10},
+				cqlType:   "int",
+				protocolV: primitive.ProtocolVersion4,
+			},
+			want:    int32(10),
+			wantErr: false,
+		},
+		{
+			name: "Decode timestamp value",
+			args: args{
+				value:     []byte{0, 0, 1, 96, 175, 4, 144, 0},
+				cqlType:   "timestamp",
+				protocolV: primitive.ProtocolVersion4,
+			},
+			want:    time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantErr: false,
+		},
+		{
+			name: "Decode bigint value",
+			args: args{
+				value:     []byte{0, 0, 0, 0, 0, 0, 0, 10},
+				cqlType:   "bigint",
+				protocolV: primitive.ProtocolVersion4,
+			},
+			want:    int64(10),
+			wantErr: false,
+		},
+		{
+			name: "Decode boolean value (true)",
+			args: args{
+				value:     []byte{1},
+				cqlType:   "boolean",
+				protocolV: primitive.ProtocolVersion4,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Decode float value",
+			args: args{
+				value:     []byte{0x40, 0x49, 0x0f, 0xdb},
+				cqlType:   "float",
+				protocolV: primitive.ProtocolVersion4,
+			},
+			want:    float32(3.141592653589793),
+			wantErr: false,
+		},
+		{
+			name: "Decode double value",
+			args: args{
+				value:     []byte{0x40, 0x09, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18},
+				cqlType:   "double",
+				protocolV: primitive.ProtocolVersion4,
+			},
+			want:    float64(3.141592653589793),
+			wantErr: false,
+		},
+		{
+			name: "Decode blob value",
+			args: args{
+				value:     []byte{0x01, 0x02, 0x03, 0x04}, // represents a binary blob
+				cqlType:   "blob",
+				protocolV: primitive.ProtocolVersion4,
+			},
+			want:    []byte{0x01, 0x02, 0x03, 0x04},
+			wantErr: false,
+		},
+		{
+			name: "Decode text value",
+			args: args{
+				value:     []byte("hello"),
+				cqlType:   "text",
+				protocolV: primitive.ProtocolVersion4,
+			},
+			want:    "hello",
+			wantErr: false,
+		},
+		{
+			name: "Unsupported CQL type",
+			args: args{
+				value:     []byte{0, 0, 0, 0},
+				cqlType:   "unsupported_type",
+				protocolV: primitive.ProtocolVersion4,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Error in decoding",
+			args: args{
+				value:     []byte{0, 0},
+				cqlType:   "int",
+				protocolV: primitive.ProtocolVersion4,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DecodeEncodedValues(tt.args.value, tt.args.cqlType, tt.args.protocolV)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DecodeEncodedValues() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DecodeEncodedValues() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeBytesToCassandraColumnType(t *testing.T) {
+	bigIntList := []int64{}
+	bigIntList = append(bigIntList, 12)
+
+	type args struct {
+		b               []byte
+		choice          datatype.PrimitiveType
+		protocolVersion primitive.ProtocolVersion
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name: "Decode varchar",
+			args: args{
+				b:               []byte("test string"),
+				choice:          datatype.Varchar,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    "test string",
+			wantErr: false,
+		},
+		{
+			name: "Decode double",
+			args: args{
+				b:               []byte{64, 9, 33, 251, 84, 68, 45, 24},
+				choice:          datatype.Double,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    float64(3.141592653589793),
+			wantErr: false,
+		},
+		{
+			name: "Decode double with float",
+			args: args{
+				b:               []byte{64, 9, 33, 251, 84, 68, 45, 24},
+				choice:          datatype.Float,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Decode float",
+			args: args{
+				b:               []byte{63, 133, 235, 81},
+				choice:          datatype.Float,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    float32(1.046244),
+			wantErr: false,
+		},
+		{
+			name: "Decode bigint",
+			args: args{
+				b:               []byte{0, 0, 0, 0, 0, 0, 0, 1},
+				choice:          datatype.Bigint,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    int64(1),
+			wantErr: false,
+		},
+		{
+			name: "Decode int",
+			args: args{
+				b:               []byte{0, 0, 0, 1},
+				choice:          datatype.Int,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    int64(1),
+			wantErr: false,
+		},
+		{
+			name: "Decode boolean",
+			args: args{
+				b:               []byte{1},
+				choice:          datatype.Boolean,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Decode uuid",
+			args: args{
+				b:               []byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0}, // Represents a UUID in bytes
+				choice:          datatype.Uuid,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    "12345678-9abc-def0-1234-56789abcdef0",
+			wantErr: false,
+		},
+		{
+			name: "Error in Decode uuid",
+			args: args{
+				b:               []byte{0x80, 0x00, 0x00, 0x00},
+				choice:          datatype.Uuid,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Error in Decode Int",
+			args: args{
+				b:               []byte("hello"),
+				choice:          datatype.Int,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Decode date",
+			args: args{
+				b:               []byte{0x80, 0x00, 0x00, 0x00},
+				choice:          datatype.Date,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    time.Unix(0, 0).UTC(),
+			wantErr: false,
+		},
+		{
+			name: "Decode blob",
+			args: args{
+				b:               []byte{0x01, 0x02, 0x03},
+				choice:          datatype.Blob,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    []byte{0x01, 0x02, 0x03},
+			wantErr: false,
+		},
+		{
+			name: "Decode Timestamp",
+			args: args{
+				b:               []byte{0, 0, 1, 96, 175, 4, 144, 0},
+				choice:          datatype.Timestamp,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC),
+			wantErr: false,
+		},
+		{
+			name: "Should go in the default and throw error",
+			args: args{
+				b:               []byte{0, 0, 1, 96, 175, 4, 144, 0},
+				choice:          datatype.Smallint,
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Should go in the default and run the bigint list",
+			args: args{
+				b:               []byte{0, 0, 0, 1, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 12},
+				choice:          datatype.NewListType(datatype.Bigint),
+				protocolVersion: primitive.ProtocolVersion4,
+			},
+			want:    bigIntList,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DecodeBytesToCassandraColumnType(tt.args.b, tt.args.choice, tt.args.protocolVersion)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DecodeBytesToCassandraColumnType() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DecodeBytesToCassandraColumnType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetupLogger(t *testing.T) {
+	type args struct {
+		logLevel     string
+		loggerConfig *LoggerConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "info log level",
+			args: args{
+				logLevel:     "info",
+				loggerConfig: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "debug log level",
+			args: args{
+				logLevel:     "debug",
+				loggerConfig: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "error log level",
+			args: args{
+				logLevel:     "error",
+				loggerConfig: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "warn log level",
+			args: args{
+				logLevel:     "warn",
+				loggerConfig: nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "default log level",
+			args: args{
+				logLevel:     "default",
+				loggerConfig: nil,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SetupLogger(tt.args.logLevel, tt.args.loggerConfig)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetupLogger() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got == nil {
+				t.Errorf("SetupLogger() = %v", got)
+			}
+		})
+	}
+}
+
+func Test_defaultIfZero(t *testing.T) {
+	type args struct {
+		value        int
+		defaultValue int
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "Return actual value",
+			args: args{
+				value:        1,
+				defaultValue: 1,
+			},
+			want: 1,
+		},
+		{
+			name: "Return default value",
+			args: args{
+				value:        0,
+				defaultValue: 11,
+			},
+			want: 11,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := defaultIfZero(tt.args.value, tt.args.defaultValue); got != tt.want {
+				t.Errorf("defaultIfZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_defaultIfEmpty(t *testing.T) {
+	type args struct {
+		value        string
+		defaultValue string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Return actual value",
+			args: args{
+				value:        "abcd",
+				defaultValue: "",
+			},
+			want: "abcd",
+		},
+		{
+			name: "Return default value",
+			args: args{
+				value:        "",
+				defaultValue: "abcd",
+			},
+			want: "abcd",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := defaultIfEmpty(tt.args.value, tt.args.defaultValue); got != tt.want {
+				t.Errorf("defaultIfEmpty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTypeConversion(t *testing.T) {
+	protocalV := primitive.ProtocolVersion4
+	tests := []struct {
+		name            string
+		input           interface{}
+		expected        []byte
+		wantErr         bool
+		protocalVersion primitive.ProtocolVersion
+	}{
+		{
+			name:            "String",
+			input:           "example string",
+			expected:        []byte{'e', 'x', 'a', 'm', 'p', 'l', 'e', ' ', 's', 't', 'r', 'i', 'n', 'g'},
+			protocalVersion: protocalV,
+		},
+		{
+			name:            "Int64",
+			input:           int64(12345),
+			expected:        []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x30, 0x39},
+			protocalVersion: protocalV,
+		},
+		{
+			name:            "Boolean",
+			input:           true,
+			expected:        []byte{0x01},
+			protocalVersion: protocalV,
+		},
+		{
+			name:            "Float64",
+			input:           123.45,
+			expected:        []byte{0x40, 0x5E, 0xDC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCD},
+			protocalVersion: protocalV,
+		},
+		{
+			name:            "Timestamp",
+			input:           time.Date(2021, time.April, 10, 12, 0, 0, 0, time.UTC),
+			expected:        []byte{0x00, 0x00, 0x01, 0x78, 0xBB, 0xA7, 0x32, 0x00},
+			protocalVersion: protocalV,
+		},
+		{
+			name:            "Byte",
+			input:           []byte{0x01, 0x02, 0x03, 0x04},
+			expected:        []byte{0x01, 0x02, 0x03, 0x04},
+			protocalVersion: protocalV,
+		},
+		{
+			name:            "String Error Case",
+			input:           struct{}{},
+			wantErr:         true,
+			protocalVersion: protocalV,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TypeConversion(tt.input, tt.protocalVersion)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TypeConversion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("TypeConversion(%v) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add utilities module for common helper functions

- Introduced the `utilities` module containing common helper functions used across the application
- Added reusable functions for data validation, string manipulation, file handling, and error logging
- Ensured utility functions are modular and easily maintainable for future expansion
- Improved code maintainability by centralizing commonly used functions in a single module

This commit enhances overall application efficiency by consolidating utility functions for consistent, reusable operations.