### PR TITLE
Switching from mocks to concrete classes to fix tests

### DIFF
--- a/kafka-connect-bigtable-sink/sink/src/test/java/com/google/cloud/kafka/connect/bigtable/autocreate/BigtableSchemaManagerTest.java
+++ b/kafka-connect-bigtable-sink/sink/src/test/java/com/google/cloud/kafka/connect/bigtable/autocreate/BigtableSchemaManagerTest.java
@@ -733,7 +733,7 @@ public class BigtableSchemaManagerTest {
   private Table mockTable(String tableName, Set<String> tableColumnFamilies) {
     com.google.bigtable.admin.v2.Table.Builder builder =
         com.google.bigtable.admin.v2.Table.newBuilder()
-            .setName(tableName);
+            .setName("projects/unused/instances/unused/tables/"+tableName);
     for (String tableColumnFamily : tableColumnFamilies) {
       GCRules.GCRule gcRule = GCRULES.maxVersions(1);
       com.google.bigtable.admin.v2.ColumnFamily columnFamily = com.google.bigtable.admin.v2.ColumnFamily.newBuilder()


### PR DESCRIPTION
removing more mocks of final classes that throw errors when strict mockito is used because they're mocks of final classes. Opted to create the table resources from proto because that's how we do it in the [hbase lib](https://github.com/googleapis/java-bigtable-hbase/blob/bf611261a86867e875916c8e5199b32f4b8e93e9/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TestTableAdapter2x.java#L73) 