### PR TITLE
Remove incorrect parseTimestamp unit tests

### DIFF
--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/translator/utils.go
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/translator/utils.go
@@ -98,9 +98,7 @@ func hasUsingTimestamp(query string) bool {
 // "2024-02-05T14:00:00Z",
 // "2024-02-05 14:00:00",
 // "2024/02/05 14:00:00",
-// "1672522562",             // Unix timestamp (seconds)
 // "1672522562000",          // Unix timestamp (milliseconds)
-// "1672522562000000",       // Unix timestamp (microseconds)
 func parseTimestamp(timestampStr string) (time.Time, error) {
 	// Define multiple layouts to try
 	layouts := []string{

--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/translator/utils_test.go
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/translator/utils_test.go
@@ -89,19 +89,19 @@ func TestParseTimestamp(t *testing.T) {
 			expected: time.Date(2024, 2, 5, 14, 0, 0, 0, time.UTC),
 		},
 		{
-			name:     "Unix timestamp (seconds)",
-			input:    "1672522562",
-			expected: time.Unix(1672522562, 0),
-		},
-		{
-			name:     "Unix timestamp (milliseconds)",
+			name:     "Unix timestamp",
 			input:    "1672522562000",
 			expected: time.Unix(0, 1672522562000*int64(time.Millisecond)),
 		},
 		{
-			name:     "Unix timestamp (microseconds)",
-			input:    "1672522562000000",
-			expected: time.Unix(0, 1672522562000000*int64(time.Microsecond)),
+			name:     "Unix timestamp epoch",
+			input:    "0",
+			expected: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "Unix timestamp negative",
+			input:    "-10000",
+			expected: time.Date(1969, 12, 31, 23, 59, 50, 0, time.UTC),
 		},
 		{
 			name:    "Invalid format",

--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/translator/utils_test.go
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/translator/utils_test.go
@@ -91,7 +91,7 @@ func TestParseTimestamp(t *testing.T) {
 		{
 			name:     "Unix timestamp",
 			input:    "1672522562000",
-			expected: time.Unix(0, 1672522562000*int64(time.Millisecond)),
+expected: time.Unix(1672522562, 0).UTC(),
 		},
 		{
 			name:     "Unix timestamp epoch",

--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/translator/utils_test.go
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/translator/utils_test.go
@@ -91,7 +91,7 @@ func TestParseTimestamp(t *testing.T) {
 		{
 			name:     "Unix timestamp",
 			input:    "1672522562000",
-expected: time.Unix(1672522562, 0).UTC(),
+			expected: time.Unix(1672522562, 0).UTC(),
 		},
 		{
 			name:     "Unix timestamp epoch",


### PR DESCRIPTION
our parseTimestamp implementation used to support unix timestamps in seconds and microseconds, but it no longer does after [this commit](https://github.com/GoogleCloudPlatform/cloud-bigtable-ecosystem/commit/12b69b327f20b43ebb20fd9d87307640c4fcaf0b#diff-e21a9743d25761be4727486163b4085f1df134f2f95cc6e272843bb0a12e2f55) which neglected to remove the corresponding tests. 

I'm not sure why we supported non-millisecond timestamps, or how that wouldn't have broken low timestamp values, since it's impossible to infer a precision based on the number of digits. The Cassandra docs only list millisecond precision as being supported: https://docs.datastax.com/en/cql-oss/3.x/cql/cql_reference/timestamp_type_r.html

I also added some new tests for better coverage.