### PR TITLE
feat: set session keyspace on cassandra java client

### DIFF
--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-java-client/cassandra-bigtable-java-client-lib/README.md
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-java-client/cassandra-bigtable-java-client-lib/README.md
@@ -77,6 +77,7 @@ class MyClass {
             .setInstanceId("someInstanceId")
             .setDefaultColumnFamily("someDefaultColumnFamily")
             .setBigtableChannelPoolSize(4)
+            .setDefaultKeyspace("myKeyspace")
             .disableOpenTelemetry()
             .build();
 

--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-java-client/cassandra-bigtable-java-client-lib/pom.xml
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-java-client/cassandra-bigtable-java-client-lib/pom.xml
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -50,11 +50,11 @@ limitations under the License.
         <scope>import</scope>
       </dependency>
       <dependency>
-          <groupId>org.junit</groupId>
-          <artifactId>junit-bom</artifactId>
-          <version>5.12.1</version>
-          <type>pom</type>
-          <scope>import</scope>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.12.1</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -110,9 +110,9 @@ limitations under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <scope>test</scope>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -317,7 +317,17 @@ limitations under the License.
           </execution>
         </executions>
       </plugin>
-
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <!-- Used by auto-value to ensure API backwards compatability -->
+        <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <!-- Exclude this configuration because no end users are expected to extend it -->
+            <exclude>com/google/bigtable/cassandra/BigtableCqlConfiguration</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
       <!-- Packaging -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-java-client/cassandra-bigtable-java-client-lib/src/main/java/com/google/bigtable/cassandra/BigtableCqlConfiguration.java
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-java-client/cassandra-bigtable-java-client-lib/src/main/java/com/google/bigtable/cassandra/BigtableCqlConfiguration.java
@@ -16,6 +16,7 @@ package com.google.bigtable.cassandra;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
+
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -33,53 +34,52 @@ public abstract class BigtableCqlConfiguration {
   private static final String DEFAULT_APP_PROFILE_ID = "default";
 
   /**
-   * @see BigtableCqlConfiguration.Builder#setProjectId(String)
-   *
    * @return The Google Cloud project ID.
+   * @see BigtableCqlConfiguration.Builder#setProjectId(String)
    */
   public abstract String getProjectId();
 
   /**
-   * @see BigtableCqlConfiguration.Builder#setInstanceId(String)
-   *
    * @return The Bigtable instance ID.
+   * @see BigtableCqlConfiguration.Builder#setInstanceId(String)
    */
   public abstract String getInstanceId();
 
   /**
-   * @see BigtableCqlConfiguration.Builder#setAppProfileId(String)
-   *
    * @return An {@link Optional} containing the Bigtable app profile ID.
+   * @see BigtableCqlConfiguration.Builder#setAppProfileId(String)
    */
   public abstract Optional<String> getAppProfileId();
 
   /**
-   * @see BigtableCqlConfiguration.Builder#setSchemaMappingTable
-   *
    * @return An {@link Optional} containing the schema mapping table name.
+   * @see BigtableCqlConfiguration.Builder#setSchemaMappingTable
    */
   public abstract Optional<String> getSchemaMappingTable();
 
   /**
-   * @see BigtableCqlConfiguration.Builder#setDefaultColumnFamily(String)
-   *
    * @return An {@link Optional} containing the default column family name.
+   * @see BigtableCqlConfiguration.Builder#setDefaultColumnFamily(String)
    */
   public abstract Optional<String> getDefaultColumnFamily();
 
   /**
-   * @see BigtableCqlConfiguration.Builder#setBigtableChannelPoolSize(int)
-   *
    * @return An {@link OptionalInt} containing the Bigtable channel pool size.
+   * @see BigtableCqlConfiguration.Builder#setBigtableChannelPoolSize(int)
    */
   public abstract OptionalInt getBigtableChannelPoolSize();
 
   /**
-   * @see BigtableCqlConfiguration.Builder#enableOpenTelemetry(OpenTelemetryConfiguration)
-   *
    * @return An {@link Optional} containing the {@link OpenTelemetryConfiguration}.
+   * @see BigtableCqlConfiguration.Builder#enableOpenTelemetry(OpenTelemetryConfiguration)
    */
   public abstract Optional<OpenTelemetryConfiguration> getOpenTelemetryConfiguration();
+
+  /**
+   * @return An {@link Optional} containing the default keyspace for the session.
+   * @see BigtableCqlConfiguration.Builder#setDefaultKeyspace
+   */
+  public abstract Optional<String> getDefaultKeyspace();
 
   /**
    * Creates a new {@link Builder} for {@link BigtableCqlConfiguration}.
@@ -94,7 +94,8 @@ public abstract class BigtableCqlConfiguration {
         .setSchemaMappingTable(DEFAULT_SCHEMA_MAPPING_TABLE)
         .setDefaultColumnFamily(DEFAULT_COLUMN_FAMILY)
         .setBigtableChannelPoolSize(DEFAULT_BIGTABLE_CHANNEL_POOL_SIZE)
-        .setAppProfileId(DEFAULT_APP_PROFILE_ID);
+        .setAppProfileId(DEFAULT_APP_PROFILE_ID)
+        .setDefaultKeyspace(Optional.empty());
   }
 
   /**
@@ -167,6 +168,19 @@ public abstract class BigtableCqlConfiguration {
      */
     public Builder setDefaultColumnFamily(String defaultColumnFamily) {
       this.setDefaultColumnFamily(Optional.of(defaultColumnFamily));
+      return this;
+    }
+
+    abstract Builder setDefaultKeyspace(Optional<String> keyspace);
+
+    /**
+     * Sets the default keyspace for the session.
+     *
+     * @param keyspace The default keyspace to use.
+     * @return This {@link Builder} instance.
+     */
+    public Builder setDefaultKeyspace(String keyspace) {
+      this.setDefaultKeyspace(Optional.of(keyspace));
       return this;
     }
 

--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-java-client/cassandra-bigtable-java-client-lib/src/main/java/com/google/bigtable/cassandra/internal/BigtableCqlSessionUtilsInternal.java
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-java-client/cassandra-bigtable-java-client-lib/src/main/java/com/google/bigtable/cassandra/internal/BigtableCqlSessionUtilsInternal.java
@@ -57,6 +57,7 @@ public final class BigtableCqlSessionUtilsInternal {
           .addContactEndPoint(new UdsEndpoint(udsAddress))
           .withLocalDatacenter(BIGTABLE_PROXY_LOCAL_DATACENTER)
           .withNodeStateListener(nodeStateListener)
+          .withKeyspace(bigtableCqlConfiguration.getDefaultKeyspace().orElse(null))
           .build();
       Files.delete(Paths.get(udsAddress.path()));
 

--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-java-client/cassandra-bigtable-java-client-lib/src/test/java/com/google/bigtable/cassandra/BigtableCqlConfigurationTest.java
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-java-client/cassandra-bigtable-java-client-lib/src/test/java/com/google/bigtable/cassandra/BigtableCqlConfigurationTest.java
@@ -19,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 public class BigtableCqlConfigurationTest {
 
   @Test
@@ -30,6 +32,7 @@ public class BigtableCqlConfigurationTest {
         .setDefaultColumnFamily("someColumnFamily")
         .setSchemaMappingTable("someSchemaMappingTable")
         .setBigtableChannelPoolSize(4)
+        .setDefaultKeyspace("someKeyspace")
         .enableOpenTelemetry(OpenTelemetryCollectorConfiguration.builder()
             .setServiceName("someServiceName")
             .enableMetrics("someMetricsEndpoint")
@@ -43,6 +46,7 @@ public class BigtableCqlConfigurationTest {
     assertEquals("someAppProfileId", bigtableCqlConfiguration.getAppProfileId().get());
     assertEquals("someColumnFamily", bigtableCqlConfiguration.getDefaultColumnFamily().get());
     assertEquals("someSchemaMappingTable", bigtableCqlConfiguration.getSchemaMappingTable().get());
+    assertEquals("someKeyspace", bigtableCqlConfiguration.getDefaultKeyspace().get());
     assertEquals(4, bigtableCqlConfiguration.getBigtableChannelPoolSize().getAsInt());
     assertTrue(bigtableCqlConfiguration.getOpenTelemetryConfiguration().isPresent());
 
@@ -67,6 +71,7 @@ public class BigtableCqlConfigurationTest {
     assertEquals("default", bigtableCqlConfiguration.getAppProfileId().get());
     assertEquals("cf1", bigtableCqlConfiguration.getDefaultColumnFamily().get());
     assertEquals("someSchemaMappingTable", bigtableCqlConfiguration.getSchemaMappingTable().get());
+    assertEquals(Optional.empty(), bigtableCqlConfiguration.getDefaultKeyspace());
     assertEquals(4, bigtableCqlConfiguration.getBigtableChannelPoolSize().getAsInt());
   }
 

--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-java-client/cassandra-bigtable-java-client-lib/src/test/resources/application.conf
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-java-client/cassandra-bigtable-java-client-lib/src/test/resources/application.conf
@@ -1,7 +1,7 @@
 datastax-java-driver {
   basic {
     request {
-      timeout = 30 seconds
+      timeout = 60 seconds
     }
   }
 }


### PR DESCRIPTION
Adds support for setting a default, session keyspace

```java
BigtableCqlConfiguration.builder()
        .setProjectId(projectId)
        .setInstanceId(instanceId)
        .setSchemaMappingTable(schemaMappingTable)
        .setDefaultKeyspace("my-keyspace") // <-- new method
        .build();
```