### PR TITLE
removing unnecessary test

### DIFF
--- a/kafka-connect-bigtable-sink/sink/src/test/java/com/google/cloud/kafka/connect/bigtable/BigtableSinkTaskTest.java
+++ b/kafka-connect-bigtable-sink/sink/src/test/java/com/google/cloud/kafka/connect/bigtable/BigtableSinkTaskTest.java
@@ -298,15 +298,6 @@ public class BigtableSinkTaskTest {
     assertEquals(
         (Long) (1000L * timestampMillis), (Long) task.getTimestampMicros(recordWithTimestamp));
     assertNotNull(task.getTimestampMicros(recordWithNullTimestamp));
-
-    // Assertion that the Java Bigtable client doesn't support microsecond timestamp granularity.
-    // When it starts supporting it, getTimestamp() will need to get modified.
-    assertEquals(
-        Arrays.stream(Table.TimestampGranularity.values()).collect(Collectors.toSet()),
-        Set.of(
-            Table.TimestampGranularity.TIMESTAMP_GRANULARITY_UNSPECIFIED,
-            Table.TimestampGranularity.MILLIS,
-            Table.TimestampGranularity.UNRECOGNIZED));
   }
 
   @Test


### PR DESCRIPTION
This assertion is was meant to safeguard against future API changes but it's no longer needed