### PR TITLE
Fix WHERE clause evaluating only first condition

### DIFF
--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/mem_table/engine_test.go
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/mem_table/engine_test.go
@@ -196,6 +196,23 @@ func Test_SelectEngine(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "multiple where conditions",
+			query: "select * from test_keyspace.user_info where name='u2' and age=51",
+			want: []types.GoRow{
+				{
+					"name":     "u2",
+					"age":      int64(51),
+					"email":    "fizz@buzz.net",
+					"username": "fizzle2",
+				},
+			},
+		},
+		{
+			name:  "multiple where conditions no match",
+			query: "select * from test_keyspace.user_info where name='u2' and age=80",
+			want:  nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/mem_table/in_mem_select.go
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/mem_table/in_mem_select.go
@@ -82,15 +82,25 @@ func matchesConditions(row types.GoRow, conditions []types.Condition, values *ty
 
 		switch cond.Operator {
 		case types.EQ:
-			return comparison == 0, nil
+			if comparison != 0 {
+				return false, nil
+			}
 		case types.GT:
-			return comparison > 0, nil
+			if comparison <= 0 {
+				return false, nil
+			}
 		case types.LT:
-			return comparison < 0, nil
+			if comparison >= 0 {
+				return false, nil
+			}
 		case types.GTE:
-			return comparison >= 0, nil
+			if comparison < 0 {
+				return false, nil
+			}
 		case types.LTE:
-			return comparison <= 0, nil
+			if comparison > 0 {
+				return false, nil
+			}
 		default:
 			return false, fmt.Errorf("unhandled where clause operator: '%s'", cond.Operator)
 		}


### PR DESCRIPTION
Fixes #183

## Summary

- **Bug**: `matchesConditions()` in `mem_table/in_mem_select.go` returns immediately after evaluating the first WHERE condition, silently ignoring all subsequent AND conditions
- **Fix**: Use early returns on mismatch — return `false` when a condition fails, `true` only after all conditions pass
- **Tests**: Added two test cases for multi-condition WHERE clauses (match and no-match)

## Affected queries

Any query with multiple WHERE conditions on `system_schema.*` tables, e.g.:
```sql
SELECT * FROM system_schema.columns
  WHERE keyspace_name = 'ks' AND table_name = 'tbl';
```
Previously only `keyspace_name` was evaluated; `table_name` was ignored.

## Test plan

- [x] Existing tests pass (13/13)
- [x] New test: `multiple where conditions` — verifies both conditions are applied
- [x] New test: `multiple where conditions no match` — verifies mismatch on second condition returns no rows
- [x] Verified new tests fail without the fix