### PR TITLE
Fix quoted table names rejected as invalid

### DIFF
--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/translators/common/utils.go
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/translators/common/utils.go
@@ -814,7 +814,7 @@ func ParseTable(t cql.ITableContext) (types.TableName, error) {
 		return "", errors.New("failed to parse table name")
 	}
 
-	name := t.OBJECT_NAME().GetText()
+	name := TrimDoubleQuotes(t.OBJECT_NAME().GetText())
 	if name == "" {
 		return "", errors.New("failed to parse table name")
 	}

--- a/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/translators/select_translator/translator_select_test.go
+++ b/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy/translators/select_translator/translator_select_test.go
@@ -1398,6 +1398,28 @@ func TestTranslator_TranslateSelectQuerytoBigtable(t *testing.T) {
 			sessionKeyspace: "test_keyspace",
 		},
 		{
+			name:  "Quoted table and keyspace names",
+			query: `select pk1 from "test_keyspace"."test_table" where pk1 = 'test';`,
+			want: &Want{
+				TranslatedQuery: "SELECT pk1 FROM test_table WHERE pk1 = 'test';",
+				Table:           "test_table",
+				Keyspace:        "test_keyspace",
+				SelectClause: &types.SelectClause{
+					Columns: []types.SelectedColumn{
+						*types.NewSelectedColumn("pk1", "pk1", "", types.TypeVarchar),
+					},
+				},
+				Conditions: []types.Condition{
+					{
+						Column:   mockdata.GetColumnOrDie("test_keyspace", "test_table", "pk1"),
+						Operator: types.EQ,
+						Value:    types.NewLiteralValue("test"),
+					},
+				},
+				AllParams: []*types.ParameterMetadata{},
+			},
+		},
+		{
 			name:  "Valid GROUP BY with aggregate and ORDER BY",
 			query: `select pk1, count(col_int) from test_keyspace.test_table where pk1 = 'test' GROUP BY pk1 ORDER BY pk1;`,
 			want: &Want{


### PR DESCRIPTION
Fixes #184

## Summary

- **Bug**: `ParseTable()` in `translators/common/utils.go` did not call `TrimDoubleQuotes()` before validating the table name, causing all queries with double-quoted table names to fail with `invalid table name: "..."`
- **Root cause**: `ParseKeyspace()` (line 832) and `ParseColumnContext()` (line 343) already strip quotes — `ParseTable()` was simply missing the same call
- **Fix**: Add `TrimDoubleQuotes()` call in `ParseTable()` before validation

## Affected queries

All DML/DDL with quoted table names across all translators (SELECT, INSERT, DELETE, UPDATE, CREATE, ALTER, DROP, TRUNCATE):
```sql
SELECT * FROM "bigtable"."employees_target" LIMIT 1;
```

## Test plan

- [x] New test: `Quoted table and keyspace names` — verifies quoted identifiers are accepted and stripped
- [x] Verified test fails without fix: `invalid table name: "test_table"`
- [x] Full select translator test suite passes (38/38)