### PR TITLE
feat(plugin): support agent plugin spec

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,25 +9,5 @@
   "homepage": "https://cloud.google.com/bigtable",
   "license": "Apache-2.0",
   "repository": "https://github.com/GoogleCloudPlatform/cloud-bigtable-ecosystem",
-  "skills": "./skills/",
-  "userConfig": {
-    "bigtable_project": {
-      "title": "Project ID",
-      "description": "ID of the Google Cloud project",
-      "type": "string",
-      "sensitive": false
-    },
-    "bigtable_instance": {
-      "title": "Instance",
-      "description": "ID of the Bigtable instance",
-      "type": "string",
-      "sensitive": false
-    },
-    "bigtable_cluster": {
-      "title": "Cluster",
-      "description": "ID of the Bigtable cluster (optional)",
-      "type": "string",
-      "sensitive": false
-    }
-  }
+  "skills": "./skills/"
 }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ codex
 
 See [Cursor Guide](https://cursor.com/docs/skills#installing-skills-from-github)
 
+#### Agent Plugins–compatible clients
+
+This repository is a valid [Agent Plugins](https://github.com/agentplugins/agent-plugins-spec) (v1) plugin. Any [compatible client](https://agent-plugins.org/compatible-clients) (VS Code, Cursor, GitHub Copilot, Codex, Kiro, …) can install it directly using its own built-in plugin command — skills and MCP server included — by pointing at this repository:
+
+```
+https://github.com/GoogleCloudPlatform/cloud-bigtable-ecosystem
+```
+
+See your agent's documentation for its exact install command.
+
 ## Migrations Tools
 
 *   **[Cassandra-Bigtable Adapter](https://github.com/GoogleCloudPlatform/cloud-bigtable-ecosystem/tree/main/cassandra-bigtable-migration-tools/cassandra-bigtable-proxy)** - This Proxy adapter allows existing Cassandra-based applications to connect seamlessly to Bigtable. This adapter functions as a wire-compatible Cassandra interface, enabling interaction via CQL with minimal configuration. It can be deployed on the same compute as your application or standalone.

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "bigtable": {
+      "type": "streamable-http",
+      "url": "https://bigtableadmin.googleapis.com/mcp"
+    }
+  }
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "bigtable",
+  "version": "0.0.1",
+  "description": "Official plugin for Google Cloud Bigtable. Manage instances/tables, design schemas, query data using SQL or client libraries, and more",
+  "author": {
+    "name": "Google LLC",
+    "email": "bigtable-cloud@google.com"
+  },
+  "homepage": "https://cloud.google.com/bigtable",
+  "repository": "https://github.com/GoogleCloudPlatform/cloud-bigtable-ecosystem",
+  "license": "Apache-2.0",
+  "keywords": [
+    "bigtable",
+    "google-cloud",
+    "database"
+  ]
+}


### PR DESCRIPTION
This PR makes this repo a valid [Agent Plugins](https://github.com/agentplugins/agent-plugins-spec) plugin so it can be installed into any supported agent.

The PR also removes `userConfigs` for Claude Code which is not used.