### PR TITLE
feat: link versions and releasing for all cassandra components

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -21,5 +21,12 @@
       "component": "kafka-connect-bigtable-sink",
       "release-type": "java-yoshi"
     }
-  }
+  },
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "cassandra-migration-tools",
+      "components": ["cassandra-bigtable-java-client", "cassandra-bigtable-proxy"]
+    }
+  ]
 }


### PR DESCRIPTION
This links the versions of all Cassandra components together.  The Java client will automatically release when the proxy releases now. We will get some weird version bumps to the proxy when the java client has changes of it's own but most updates are to the proxy. It will also be more clear which proxy version you get with the java client.

https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#linked-versions

