### PR TITLE
rollback linked versions for cassandra tools

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -21,12 +21,5 @@
       "component": "kafka-connect-bigtable-sink",
       "release-type": "java-yoshi"
     }
-  },
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "cassandra-migration-tools",
-      "components": ["cassandra-bigtable-java-client", "cassandra-bigtable-proxy"]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Linked versions didn't work, probably because the cassandra tools have different release types.